### PR TITLE
add: minimal bottle dev server

### DIFF
--- a/bin/__main__.py
+++ b/bin/__main__.py
@@ -1,0 +1,4 @@
+import bottle
+from bin import bin
+
+bottle.run(host='localhost', port=8080, debug=True, reloader=True)

--- a/bin/bin.py
+++ b/bin/bin.py
@@ -1,0 +1,5 @@
+import bottle
+
+@bottle.route('/')
+def index():
+    return


### PR DESCRIPTION
Added a dummy route / that returns a blank page. To run a development
server on localhost:8080, execute the following command:

	venv/bin/python -m bin

Related to #4