### PR TITLE
imp: lang detection for multi-part forms

### DIFF
--- a/bin/utils.py
+++ b/bin/utils.py
@@ -1,0 +1,31 @@
+languages = [
+    ('py', 'python'),
+    ('js', 'javascript'),
+    ('md', 'markdown'),
+    ('cs', 'csharp'),
+    ('sh', 'shell'),
+    ('kts', 'kotlin'),
+    ('h', 'objectivec'),
+    ('hpp', 'cpp'),
+    ('rb', 'ruby'),
+    ('rs', 'rust'),
+    ('ts', 'typescript'),
+    ('yml', 'yaml'),
+    ('txt', 'plaintext'),
+]
+exttolang = {ext: language for ext, language in languages}
+langtoext = {language: ext for ext, language in languages}
+
+
+def parse_extension(lang_or_ext):
+    lang_or_ext = (lang_or_ext or '').casefold()
+    if lang_or_ext in exttolang:
+        return lang_or_ext
+    return langtoext.get(lang_or_ext, 'txt')
+
+
+def parse_language(lang_or_ext):
+    lang_or_ext = (lang_or_ext or '').casefold()
+    if lang_or_ext in langtoext:
+        return lang_or_ext
+    return exttolang.get(lang_or_ext, 'plaintext')


### PR DESCRIPTION
When sending a file via curl, it is easier to send it via a multipart
form like would a HTML `<input type=file>` do. Multipart forms have
dedicated headers per part making it possible to extract the original
filename via its `Content-Disposition` header.

The `languages` databases (and its two indexes) have been moved to a
dedicated module `utils.py`. Two new functions `parse_extension` and
`parse_language` have been included in that module, they ease the
extraction of the language or extension from a user given string.

Related to #8