### PR TITLE
[ADD] Make snippets have a max number of views

### DIFF
--- a/bin/config.py
+++ b/bin/config.py
@@ -18,7 +18,9 @@ load_dotenv(options.config)  # will use a sensitive default if -c is omitted
 
 HOST = os.getenv('RTDBIN_HOST', 'localhost')
 PORT = int(os.getenv('RTDBIN_PORT', options.port))
+SNIPPET_DEAULT_EXTENSION = os.getenv('RTDBIN_SNIPPET_DEFAULT_EXTENSION')
 SNIPPET_MAX_SIZE = int(os.getenv('RTDBIN_SNIPPET_MAX_SIZE', 16384))
+DEFAULT_SNIPPET_MAX_USAGE = int(os.getenv('RTDBIN_DEFAULT_SNIPPET_MAX_VIEWS')) if os.getenv('RTDBIN_DEFAULT_SNIPPET_MAX_VIEWS') else float('+inf')
 REDIS_ENABLED = strtobool(os.getenv('REDIS_ENABLED', options.redis_enabled))
 REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
 REDIS_PORT = int(os.getenv('REDIS_PORT', 6379))

--- a/bin/controller.py
+++ b/bin/controller.py
@@ -40,7 +40,7 @@ def post_new():
     max_views = float('+inf')
     if not forms.get('infinite_views'):
         try:
-            max_views = int(forms.get('max_views'))
+            max_views = float(forms.get('max_views', float('+inf')))
             if max_views < 1:
                 raise bt.HTTPError(400, 'Max views should be greater than 0')                   # TODO: error handling in front-side
         except ValueError as e:

--- a/bin/models.py
+++ b/bin/models.py
@@ -13,27 +13,45 @@ else:
         db = {}
 
         @classmethod
-        def set(cls, ident, code):
-            cls.db[ident] = code.encode()
+        def hset(cls, ident, field, value):
+            if not cls.db.get(ident):
+                cls.db[ident] = {}
+            cls.db.get(ident)[field] = value.encode()
 
         @classmethod
-        def get(cls, ident):
+        def hgetall(cls, ident):
             return cls.db.get(ident)
 
+        @classmethod
+        def hincrby(cls, indent, field, incr):
+            cls.db.get(indent)[field] += incr
+
+
 class Snippet:
-    def __init__(self, ident, code):
+    def __init__(self, ident, code, views_left):
         self.id = ident
         self.code = code
+        self.views_left = views_left
 
     @classmethod
-    def create(cls, code):
+    def create(cls, code, views_left):
         ident = pronounceable_passwd(6)
-        database.set(ident, code)
-        return cls(ident, code)
+        database.hset(ident, "code", code)
+        database.hset(ident, "views_left", views_left)
+        return cls(ident, code, views_left)
 
     @classmethod
     def get_by_id(cls, snippet_id):
-        code = database.get(snippet_id)
+        snippet = database.hgetall(snippet_id)
+        code = snippet[b'code'].decode('utf-8')
+        views_left = snippet[b'views_left'].decode('utf-8')
         if not code:
             raise KeyError('Snippet not fond')
-        return cls(snippet_id, code.decode('utf-8'))
+
+        if views_left != 'inf':
+            if int(views_left) - 1 <= 0:
+                database.delete(snippet_id)
+            else:
+                database.hincrby(snippet_id, 'views_left', -1)
+
+        return cls(snippet_id, code, views_left)

--- a/bin/views/newform.html
+++ b/bin/views/newform.html
@@ -24,6 +24,13 @@
                 <option value="html">HTML</option>
                 <option value="css">CSS</option>
             </select>
+
+            <!-- TODO: style these ass trash looking inputs (you can change the labels but don't change the names) -->
+            <label for="infinite_views">Vues infinies</label>
+            <input type=checkbox name="infinite_views" checked>
+            <label for="max_views">Nombre de vues max</label>    <!-- TODO: don't show this input if infinite_views input is checked -->
+            <input type=number name="max_views">
+
             <button type=submit>
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                   <path d="M17.414 2.586a2 2 0 00-2.828 0L7 10.172V13h2.828l7.586-7.586a2 2 0 000-2.828z" />

--- a/bin/views/newform.html
+++ b/bin/views/newform.html
@@ -25,12 +25,6 @@
                 <option value="css">CSS</option>
             </select>
 
-            <!-- TODO: style these ass trash looking inputs (you can change the labels but don't change the names) -->
-            <label for="infinite_views">Vues infinies</label>
-            <input type=checkbox name="infinite_views" checked>
-            <label for="max_views">Nombre de vues max</label>    <!-- TODO: don't show this input if infinite_views input is checked -->
-            <input type=number name="max_views">
-
             <button type=submit>
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                   <path d="M17.414 2.586a2 2 0 00-2.828 0L7 10.172V13h2.828l7.586-7.586a2 2 0 000-2.828z" />


### PR DESCRIPTION
```
The user is now able to set a maximum number of views/uses on his
snippets. By default, this number is infinite. The user can turn off the
infinite views by unchecking the 'infinite_views checkbox and by
entering a views number in the 'max_views' input field (it has to be a
number greater than 0). Every time the snippet's page is visited, its
views left decrease, and when it gets to 0, the snippet is deleted from
the database.
```