### PR TITLE
Fix frontend major bug

### DIFF
--- a/bin/assets/styles/fullpage.css
+++ b/bin/assets/styles/fullpage.css
@@ -1,0 +1,4 @@
+html, body {
+    height: 100vh;
+    width: 100vw;
+}

--- a/bin/assets/styles/style.css
+++ b/bin/assets/styles/style.css
@@ -1,8 +1,3 @@
-html, body {
-    height: 100vh;
-    width: 100vw;
-}
-
 * {
     outline: none;
 }

--- a/bin/views/newform.html
+++ b/bin/views/newform.html
@@ -2,6 +2,7 @@
 <html lang=fr>
     <head>
         % include('head.html')
+        <link rel=stylesheet href="/assets/styles/fullpage.css">
         <script src="/assets/scripts/newform-button.js" defer></script>
     </head>
     <body>


### PR DESCRIPTION
## Bug description
By setting height and width of the `body` and `html` to the viewport size, the code was let alone in a scrollable "block" (body) to the size of the viewport, making the line numbers useless and invalid.
When out of this block, the line count was correct but full of empty lines.

## Screenshots
![image](https://user-images.githubusercontent.com/26577763/101238391-36821100-36e0-11eb-92c5-b1abdfa9e34a.png)
![image](https://user-images.githubusercontent.com/26577763/101238400-47328700-36e0-11eb-937f-f7ef0c590ed5.png)
![image](https://user-images.githubusercontent.com/26577763/101238404-531e4900-36e0-11eb-9f2e-5ebe69fd3894.png)
![image](https://user-images.githubusercontent.com/26577763/101238408-5e717480-36e0-11eb-88cb-9d130c06b2ff.png)
