### PR TITLE
imp: Unittests

### DIFF
--- a/bin/__init__.py
+++ b/bin/__init__.py
@@ -3,5 +3,7 @@ import bottle
 root = __import__("pathlib").Path(__file__).resolve().parent
 bottle.TEMPLATE_PATH = [str(root / 'views')]
 
+from . import config
+from . import utils
 from . import controller
 from . import models

--- a/bin/config.py
+++ b/bin/config.py
@@ -14,7 +14,7 @@ cli = ArgumentParser()
 cli.add_argument('port', nargs='?', type=int, default=8012)
 cli.add_argument('-c', '--config')
 cli.add_argument('--no-redis', dest='redis_enabled', action='store_false')
-options = cli.parse_args()
+options = cli.parse_known_args()[0]
 load_dotenv(options.config)  # will use a sensitive default if -c is omitted
 
 HOST = os.getenv('RTDBIN_HOST', 'localhost')

--- a/bin/models.py
+++ b/bin/models.py
@@ -7,8 +7,6 @@ from bin import config
 
 if config.REDIS_ENABLED:
     database = Redis(host=config.REDIS_HOST, port=config.REDIS_PORT)
-else:
-    raise EnvironmentError("In-memory database is not supported for now")
 
 
 class Snippet:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,138 @@
+import bottle
+import signal
+import unittest
+import urllib.request as urlreq
+from bin import config
+from bin.models import Snippet
+from bottle import template as bottle_template
+from html.parser import HTMLParser
+from threading import Thread
+from unittest.mock import patch, MagicMock
+
+
+snippet_lipsum = Snippet(ident='lipsum', code="Lipsum", views_left=float('+inf'))
+snippet_python = Snippet(ident='egg', code='print("Hello world")', views_left=float('+inf'))
+
+
+class HTMLSanitizer(HTMLParser):
+    def __init__(self, assertEqual, assertIn):
+        self.assertIn = assertIn
+        self.assertEqual = assertEqual
+        self.pairtags = {
+            'a', 'abbr', 'acronym', 'address', 'applet', 'article',
+            'aside', 'audio', 'b', 'basefont', 'bdi', 'bdo', 'big',
+            'blockquote', 'body', 'button', 'canvas', 'caption',
+            'center', 'cite', 'code', 'colgroup', 'data', 'datalist',
+            'dd', 'del', 'details', 'dfn', 'dialog', 'dir', 'div', 'dl', 'dt',
+            'em', 'fieldset', 'figcaption', 'figure', 'font',
+            'footer', 'form', 'frame', 'frameset', 'head', 'header', 'hgroup',
+            'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'html', 'i', 'iframe',
+            'ins', 'kbd', 'label', 'legend', 'li',
+            'main', 'map', 'mark', 'menu', 'menuitem', 'meter',
+            'nav', 'noframes', 'noscript', 'object', 'ol', 'optgroup',
+            'option', 'output', 'p', 'picture', 'pre', 'progress',
+            'q', 'rp', 'rt', 'ruby', 's', 'samp', 'script', 'section',
+            'select', 'small', 'span', 'strike', 'strong', 'style',
+            'sub', 'summary', 'sup', 'svg', 'table', 'tbody', 'td', 'template',
+            'textarea', 'tfoot', 'th', 'thead', 'time', 'title', 'tr',
+            'tt', 'u', 'ul', 'var', 'video',
+        }
+        self.singletags = {
+            "area", "base", "br", "col", "command", "embed", "hr", "img",
+            "input", "keygen", "link", "meta", "param", "source", "track",
+            "wbr",
+        }
+        self.stack = []
+        self.insvg = False
+        super().__init__()
+
+    def handle_starttag(self, starttag, attrs):
+        if self.stack and self.stack[-1] == 'svg':
+            return
+
+        self.assertIn(starttag, self.pairtags | self.singletags, "unknown html tag")
+        if starttag in self.pairtags:
+            self.stack.append(starttag)
+
+    def handle_startendtag(self, startendtag, attrs):
+        if self.stack and self.stack[-1] == 'svg':
+            return
+
+        self.assertIn(startendtag, self.singletags)
+
+    def handle_endtag(self, endtag):
+        if self.stack[-1] == 'svg' and endtag != 'svg':
+            return
+
+        starttag = self.stack.pop()
+        self.assertEqual(starttag, endtag, "malformatted html")
+
+
+class TestController(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        print("Starting builtin server in a daemon thread")
+        th = Thread(target=bottle.run, daemon=True, kwargs={
+            "host": "localhost",
+            "port": 8012,
+            "debug": True
+        })
+        th.start()
+
+        # Wait up to 2 second the server is ready
+        for i in range(10):
+            th.join(.2)
+            try:
+                urlreq.urlopen("http://localhost:8012/health")
+            except ConnectionRefusedError:
+                if i == 9:
+                    raise
+            else:
+                break
+
+    def setUp(self):
+        self.html_sanitizer = HTMLSanitizer(self.assertEqual, self.assertIn)
+        bottle.template = MagicMock()
+        bottle.template.side_effect = bottle_template
+
+    def tearDown(self):
+        bottle.template = bottle_template
+
+    def test_healthcheck(self):
+        with urlreq.urlopen("http://localhost:8012/health") as res:
+            self.assertEqual(res.status, 200)
+
+    def test_get_new_form(self):
+        with urlreq.urlopen("http://localhost:8012/") as res:
+            bottle.template.assert_called_with('newform.html')
+            self.assertEqual(res.status, 200)
+            self.html_sanitizer.feed(res.read().decode())
+
+    def test_get_html(self):
+        with patch('bin.models.Snippet') as MockSnippet:
+            MockSnippet.get_by_id.return_value = snippet_lipsum
+            with urlreq.urlopen("http://localhost:8012/lipsum") as res:
+                bottle.template.assert_called_with(
+                    'highlight', code=snippet_lipsum.code, language=config.DEFAULT_LANGUAGE)
+                self.assertEqual(res.status, 200)
+                self.html_sanitizer.feed(res.read().decode())
+
+            MockSnippet.get_by_id.return_value = snippet_python
+            with urlreq.urlopen("http://localhost:8012/egg.py") as res:
+                bottle.template.assert_called_with(
+                    'highlight', code=snippet_python.code, language='python')
+                self.assertEqual(res.status, 200)
+                self.html_sanitizer.feed(res.read().decode())
+
+    def test_get_raw(self):
+        with patch('bin.models.Snippet') as MockSnippet:
+            MockSnippet.get_by_id.return_value = snippet_lipsum
+            with urlreq.urlopen("http://localhost:8012/raw/lipsum") as res:
+                self.assertEqual(res.status, 200)
+                self.assertEqual(res.read().decode(), snippet_lipsum.code)
+
+            MockSnippet.get_by_id.return_value = snippet_python
+            with urlreq.urlopen("http://localhost:8012/raw/egg.py") as res:
+                self.assertEqual(res.status, 200)
+                self.assertEqual(res.read().decode(), snippet_python.code)


### PR DESCRIPTION
This commit introduce a first set of unit tests using the python
standard's unittest framework.

To run the test suite, go to the project's root directory (where the
README.md is) and run the following command:

    python -m unitttest

If the module is installed in a virtual environment, you can either
activate that very environment or replace `python` by the fullpath to
the interpreter of your environment.

The implementation of the test suite need various code adaptation here
and there:

1. As it is only possible to mock classes *at the module level*,
   directly importing a model class is now forbidden. Doing
   `from bin.models import Snippet` copies the reference to the
   `Snippet` class to the local module, hence if a test mocks the
   Snippet class, the "local" module is not affected because it stills
   hold the reference to the original non-mocked module.
2. In the configuration, we `parse_args` by `parse_known_args` so it
   does not clash with unittest's cli.
3. We removed the exception raised when starting the project without
   database. This is required to run the test suite without database by
   mocking the various models.

Related to #44