### PR TITLE
fix: force text/plain content-type on /raw

### DIFF
--- a/bin/controller.py
+++ b/bin/controller.py
@@ -72,4 +72,6 @@ def get_raw(snippet_id, ext=None):
         snippet = models.Snippet.get_by_id(snippet_id)
     except KeyError:
         raise bt.HTTPError(404, "Snippet not found")
+
+    bt.response.headers['Content-Type'] = 'text/plain'
     return snippet.code


### PR DESCRIPTION
The default content-type set by bottle is `text/html` which allow a user
to post a HTML snippet with Javascript code embed and to get his code
executed by victim's browsers if they reach the /raw url.

![2020-12-23_19-33-04](https://user-images.githubusercontent.com/8208953/103027249-c4ba1c00-4555-11eb-8c64-bc92f2450e2e.png)

Closes #49