### PR TITLE
imp: remove --no-redis cli argument

### DIFF
--- a/bin/config.py
+++ b/bin/config.py
@@ -13,7 +13,6 @@ def strtobool(s):
 cli = ArgumentParser()
 cli.add_argument('port', nargs='?', type=int, default=8012)
 cli.add_argument('-c', '--config')
-cli.add_argument('--no-redis', dest='redis_enabled', action='store_false')
 options = cli.parse_known_args()[0]
 load_dotenv(options.config)  # will use a sensitive default if -c is omitted
 
@@ -23,6 +22,5 @@ MAXSIZE = Byte(os.getenv('RTDBIN_MAXSIZE', '16kiB'))
 DEFAULT_LANGUAGE = os.getenv('RTDBIN_DEFAULT_LANGUAGE', 'text')
 DEFAULT_MAXUSAGE = int(os.getenv('RTDBIN_DEFAULT_MAXUSAGE', -1))
 DEFAULT_LIFETIME = Time(os.getenv('RTDBIN_DEFAULT_LIFETIME', -1))
-REDIS_ENABLED = strtobool(os.getenv('REDIS_ENABLED', options.redis_enabled))
 REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
 REDIS_PORT = int(os.getenv('REDIS_PORT', 6379))

--- a/bin/models.py
+++ b/bin/models.py
@@ -5,8 +5,7 @@ from genpw import pronounceable_passwd
 from bin import config
 
 
-if config.REDIS_ENABLED:
-    database = Redis(host=config.REDIS_HOST, port=config.REDIS_PORT)
+database = Redis(host=config.REDIS_HOST, port=config.REDIS_PORT)
 
 
 class Snippet:


### PR DESCRIPTION
The original idea was to have a dual database implementation, one pure
python implementation in-memory for testing and developing purposes and
one full featured redis database in production.

It proves cumbersome to maintain an in-memory database and the
implementation was removed. The recent introduction of unittests showed
it is easy to mock the various models.

Many contributers now share the idea that running bin without a redis
database is a bad idea.