### PR TITLE
imp: anchors

### DIFF
--- a/bin/assets/scripts/loc.js
+++ b/bin/assets/scripts/loc.js
@@ -1,2 +1,45 @@
-const locWidth = document.getElementsByTagName('li').length.toString().length;
-document.documentElement.style.setProperty('--loc-width', `${locWidth - 0.5}em`);
+const locs = [...document.getElementsByClassName('line-number')];
+const selectedLocs = document.getElementsByClassName('selected');
+
+handleHash();
+window.addEventListener('hashchange', () => {
+  [...selectedLocs].forEach((e) => e.classList.remove('selected'));
+  handleHash();
+})
+
+locs.forEach((loc, i) => {
+  loc.addEventListener('click', () => {
+    // add the line location to the URL without affecting the history and without triggering a hashchange
+    window.history.replaceState(undefined, undefined, `#L${i + 1}`);
+    // remove all selected lines
+    [...selectedLocs].forEach((e) => e.classList.remove('selected'));
+    loc.nextElementSibling.classList.add('selected');
+  })
+})
+
+function handleHash() {
+  const hashMatch = location.hash.match(/^(?:#L(\d+)(?:-L(\d+))?)$/i);
+  if (!hashMatch) {
+    return;
+  }
+  let start = parseInt(hashMatch[1], 10);
+  let end = hashMatch[2] ? parseInt(hashMatch[2], 10) : undefined;
+  if (end && start > end) {
+    [start, end] = [end, start];
+  }
+  if (start <= 0 || start > locs.length || end && end <= 0 || end > locs.length) {
+    return;
+  }
+  if (!end) {
+    locs[start - 1].nextElementSibling.classList.add('selected');
+    return;
+  }
+  for (let i = start - 1; i <= locs.length && i < end; i++) {
+    const line = locs[i].nextElementSibling;
+    line.classList.add('selected');
+    if (i === start - 1) {
+      // scroll to the first line of the selection
+      line.scrollIntoView();
+    }
+  }
+}

--- a/bin/assets/scripts/newform-button.js
+++ b/bin/assets/scripts/newform-button.js
@@ -1,22 +1,8 @@
-const form = document.forms[0];
-const code = form.code;
-const button = form.getElementsByTagName('button')[0];
+const code = document.forms[0].code;
 
-button.addEventListener('click', (event) => {
-  if (!code.value) {
-    event.preventDefault();
-  }
-});
-
-code.addEventListener('input', () => {
-  if (code.value) {
-    button.classList.add('valid');
-    return;
-  }
-  button.classList.remove('valid');
-});
-
-window.addEventListener('keydown', (event) => {
+// remove the "required" error message that overflows the page
+code.addEventListener('invalid', (event) => event.preventDefault());
+code.addEventListener('keydown', (event) => {
   if (event.code === 'Tab') {
     // prevents tab from being used to navigate between browser elements
     event.preventDefault();

--- a/bin/assets/styles/style.css
+++ b/bin/assets/styles/style.css
@@ -3,10 +3,6 @@
     box-sizing: border-box;
 }
 
-:root {
-    --loc-width: 0.5em;
-}
-
 html {
     padding: 0;
 }
@@ -22,42 +18,50 @@ body {
     font-family: Consolas, monospace;
 
     padding: 0.5em;
+    tab-size: 4;
 }
 
-pre {
-    display: flex;
-    width: 100%;
-    padding: 2em 0;
-}
-
-pre code {
+.highlight {
+    padding: 1em 0.6em 1em 0;
     background: transparent !important;
-    padding: 0 !important;
     font-family: Consolas, monospace;
     font-size: 1em;
-    width: inherit;
+    overflow-x: scroll;
+    border-spacing: 0;
+    border-collapse: separate;
 }
 
-ol {
-    list-style-type: none;
-    margin: 0;
-    padding: 0 0.8em;
+tr, td {
+    vertical-align: baseline;
+    white-space: pre;
 }
 
-ol li {
-    clear: both;
+.line-content {
+    padding: 0 0 0 0.5em;
 }
 
-ol li::before {
-    content: counter(list-item) "\A0";
-    float: left;
+.line-content.selected {
+    background-color: rgba(240, 200, 100, 0.1);
+}
+
+.line-number {
+    width: 1%;
+    min-width: 2em;
+    padding: 0 0.65em;
     text-align: right;
-    width: var(--loc-width);
-    padding-right: 1em;
+    font-family: Consolas, monospace;
+    cursor: pointer;
+    user-select: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+}
+
+.line-number::before {
+    content: attr(value);
 }
 
 .post-snippet {
-    padding: 0.3em 0.6em;
+    padding: 0.3em 0 0.3em 0.6em;
     width: 100%;
     height: 100%;
 }
@@ -80,7 +84,7 @@ ol li::before {
     bottom: 0;
     left: 0;
     right: 0;
-    padding: 0 0.5em 0.5em 0.5em;
+    padding: 0 1.5em 1em 0.5em;
     pointer-events: none;
     display: flex;
     align-items: center;

--- a/bin/assets/styles/style.css
+++ b/bin/assets/styles/style.css
@@ -118,7 +118,7 @@ input[type="number"] {
     transition: all 0.2s ease;
 }
 
-.controls button.valid {
+.post-snippet:valid .controls button {
     background-color: #5cbbf7;
     cursor: pointer;
 }
@@ -131,6 +131,6 @@ input[type="number"] {
     transition: all 0.2s ease;
 }
 
-.controls button.valid svg {
+.post-snippet:valid .controls button svg {
     fill: #ffffff;
 }

--- a/bin/highlight.py
+++ b/bin/highlight.py
@@ -3,25 +3,25 @@ from pygments.lexers import get_lexer_by_name
 from pygments.formatters.html import HtmlFormatter
 
 
-class OlLiHtmlFormatter(HtmlFormatter):
+class TableHtmlFormatter(HtmlFormatter):
     def __init__(self, **options):
         super().__init__(**options)
-        if options.get('linenos', False) == 'ol':
+        if options.get('linenos', False) == 'bin-table':
             self.linenos = 3
-            self.lineseparator = '</li><!--\n--><li>'
 
     def wrap(self, source, outfile):
         if self.linenos == 3:
-            source = self._wrap_olli(source)
-        return super().wrap(source, outfile)
+            source = self._wrap_table(source)
+        yield from source
 
-    def _wrap_olli(self, inner):
-        yield 0, '<ol><li>'
-        yield from inner
-        yield 0, '</li></ol>'
+    def _wrap_table(self, inner):
+        yield 0, '<table class="highlight"><tbody>'
+        for i, (t, l) in enumerate([*inner, (1, '')]):
+            yield t, f'<tr><td class="line-number" id=L{i + 1} value={i + 1}></td><td class="line-content">{l}</td></tr>\n'
+        yield 0, '</tbody></table>'
 
 
-_html_formatter = OlLiHtmlFormatter(wrapcode=True, linenos='ol', style='monokai')
+_html_formatter = TableHtmlFormatter(linenos='bin-table', style='monokai')
 
 
 def highlight(code, language):

--- a/bin/views/newform.html
+++ b/bin/views/newform.html
@@ -6,7 +6,7 @@
     </head>
     <body>
         <form action="/new" method=POST class="post-snippet">
-            <textarea spellcheck=false placeholder="Entrer votre code." name=code autofocus></textarea>
+            <textarea spellcheck=false placeholder="Entrer votre code." name=code autofocus required></textarea>
 
             <div class="controls">
                 <input class="control" list=maxusage-presets type="number" min="-1" title="Nombre d'utilisation maximum : -1 ou 10, ect." placeholder="Nombre d'utilisation maximum : -1 ou 10, ect." name=maxusage>


### PR DESCRIPTION
Closes: #9.

Implémentation des ancres, avec une toute nouvelle structure pour le code, grâce au `table`.
Ca s'utilise de cette manière, avec admettons un bin de 20 lignes au total :
  - `#L1` : surlignement de la première ligne
  - `#L1-L20` et `#L20-L1`: surlignement de la première jusqu'à la 20eme ligne.
  - `#L0`, `#L1-L100`: aucun surlignement
Il est (volontairement) assez stricte, d'ailleurs faudrait même n'acceptez que les majuscules, car l'identifiant des ancres est en tout majuscule, donc actuellement en minuscule c'est supporté par le JS, mais le navigateur ne scrollera pas.  

J'ai aussi utiliser `required` + `:valid` a la place du JS pour la validation du formulaire avec 1 ligne de JS, juste pour enlever le message d'erreur qui débordait de la page, et qui en plus servait a rien car, c'est déjà signalé par la couleur du bouton.