### PR TITLE
fix: missing non-python files in dists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include VERSION
+graft bin/assets
+graft bin/views
+graft tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
   Programming Language :: Python :: 3 :: Only
 
 [options]
+packages = bin
 install_requires =
   bottle
   genpw
@@ -22,3 +23,6 @@ install_requires =
   redis
   # waiting for pip/setuptools to support custom package indexes:
   # pip install -i https://pypi.drlazor.be metrics
+
+[options.package_data]
+* = assets/**/*, views/*


### PR DESCRIPTION
In python there are source distribution (sdist) with developers and
contributers as target audience and there are build distribution (bdist)
with users as target audience.

A sdist will contain everything that is needed for developers to build,
test and document the source code while the bdist usualy just contains
an executable.

In our case, not only python source code should be included in both
distributions but also web assets and html templates. By default they
are not included nor in the sdist, nor in the bdist. In case of a source
distribution, the files are to be included in the `MANIFEST.in` file. In
case of a build distribution, the files are to be included in the
`package_data` option of setup.cfg. Because it is possible to install a
source distribution (`pip install bin.x.x.x.tar.gz`), every file needed
to build the sources must be included in the source distribution too.

Long story cut short : `MANIFEST.in` controls what's included in the
sdist. By default it includes a few metadata files (setup.(py|cfg),
readmes, ...) and python packages. The `package` and `package_data`
options of `setup.cfg` control what's included in the bdist.

1/ `package` now only contain `bin` and excluses other python packages,
   the unittests are no more included in the bdist, it is not necessary
   for users.
2/ `package_data` and `MANIFEST.in` now include the various web assets
   they are required to run the application.
3/ `MANIFEST.in` includes the unittests as they are valuable to devs
4/ `MANIFEST.in` includes `VERSION` as it is required by setup.py and
   because it is possible to pip install the sdist.