### PR TITLE
Intégration continue

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -9,7 +9,7 @@ on: [push, pull_request]
 #    branches: [ main ]
 
 jobs:
-  build:
+  build:    
     runs-on: ubuntu-latest
 
     steps:
@@ -29,16 +29,18 @@ jobs:
     
     - name: Build wheel
       run: python3 setup.py bdist_wheel
+      
+    - name: Get version
+      run: echo $(cat VERSION) >> BIN_VERSION
     
-    # TODO Get version code and use it here instead of hardcoding 0.0.0
     - name: Upload tar.gz
       uses: actions/upload-artifact@v2.2.1
       with:
         name: bin-archive
-        path: dist/bin-0.0.0.tar.gz
+        path: dist/bin-${{ env.BIN_VERSION }}.tar.gz
 
     - name: Upload wheel
       uses: actions/upload-artifact@v2.2.1
       with:
         name: bin-wheel
-        path: dist/bin-0.0.0-py3-none-any.whl
+        path: dist/bin-${{ env.BIN_VERSION }}-py3-none-any.whl

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -31,7 +31,7 @@ jobs:
       run: python3 setup.py bdist_wheel
       
     - name: Get version
-      run: echo $(cat VERSION) >> BIN_VERSION
+      run: echo "BIN_VERSION=$(cat VERSION)" >> $GITHUB_ENV
     
     - name: Upload tar.gz
       uses: actions/upload-artifact@v2.2.1

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,10 +1,8 @@
 name: Build artifacts
 
-# push & pr everywhere in order to test
-on: [push, pull_request]
-
-#  push:
-#    branches: [ main ]
+on:
+  push:
+    branches: [ main ]
 
 jobs:
   build:    

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Upload tar.gz
       uses: actions/upload-artifact@v2.2.1
       with:
-        name: bin-archive
+        name: bin-sources
         path: dist/bin-${{ env.BIN_VERSION }}.tar.gz
 
     - name: Upload wheel

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -5,8 +5,6 @@ on: [push, pull_request]
 
 #  push:
 #    branches: [ main ]
-#  pull_request:
-#    branches: [ main ]
 
 jobs:
   build:    

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install wheel
+        pip install wheel setuptools
     
     - name: Build tar.gz
       run: python3 setup.py sdist

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,0 +1,44 @@
+name: Build artifacts
+
+# push & pr everywhere in order to test
+on: [push, pull_request]
+
+#  push:
+#    branches: [ main ]
+#  pull_request:
+#    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install wheel
+    
+    - name: Build tar.gz
+      run: python3 setup.py sdist
+    
+    - name: Build wheel
+      run: python3 setup.py bdist_wheel
+    
+    # TODO Get version code and use it here instead of hardcoding 0.0.0
+    - name: Upload tar.gz
+      uses: actions/upload-artifact@v2.2.1
+      with:
+        name: bin-archive
+        path: dist/bin-0.0.0.tar.gz
+
+    - name: Upload wheel
+      uses: actions/upload-artifact@v2.2.1
+      with:
+        name: bin-wheel
+        path: dist/bin-0.0.0-py3-none-any.whl

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,54 @@
+name: Build Docker images
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10 # Timeout after 10 min
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ghcr.io/readthedocs-fr/bin
+          tag-sha: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+         path: /tmp/.buildx-cache
+         key: buildx-${{ github.sha }}
+         restore-keys: |
+           buildx-
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          push: ${{ github.event_name != 'pull_request' }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python application
+name: Continuous Integration
 
 on: [push, pull_request]
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,14 +18,14 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install flake8
+        pip install -r requirements.txt
+        pip install -e .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        pytest
+    - name: Run tests
+      run: python3 -m unittest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,31 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python application
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM python:3.8-alpine
 
 ENTRYPOINT python -m bin
 WORKDIR /usr/local/lib/rtd-bin
+LABEL org.opencontainers.image.source https://github.com/readthedocs-fr/bin
 
-# Install prerequisities
-RUN pip install -i https://pypi.drlazor.be metrics
 COPY . /usr/local/lib/rtd-bin
-RUN python setup.py install
+RUN pip install -q -i https://pypi.drlazor.be metrics && python setup.py -q install

--- a/bin/models.py
+++ b/bin/models.py
@@ -1,5 +1,3 @@
-import textwrap
-import itertools
 from redis import Redis
 from genpw import pronounceable_passwd
 from bin import config

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,10 +1,8 @@
 import bottle
 import html
 import re
-import signal
 import unittest
 import urllib.request as urlreq
-from bin import config
 from bin.models import Snippet
 from bottle import template as bottle_template
 from html.parser import HTMLParser
@@ -31,7 +29,7 @@ class HTMLSanitizer(HTMLParser):
             'h5', 'h6', 'html', 'i', 'iframe', 'ins', 'kbd', 'label', 'legend',
             'li', 'main', 'map', 'mark', 'menu', 'menuitem', 'meter', 'nav',
             'noframes', 'noscript', 'object', 'ol', 'output', 'p', 'picture',
-            'pre', 'progress','q', 'rp', 'rt', 'ruby', 's', 'samp', 'script',
+            'pre', 'progress', 'q', 'rp', 'rt', 'ruby', 's', 'samp', 'script',
             'section', 'select', 'small', 'span', 'strike', 'strong', 'style',
             'sub', 'summary', 'sup', 'svg', 'table', 'tbody', 'td', 'template',
             'textarea', 'tfoot', 'th', 'thead', 'time', 'title', 'tr', 'tt',


### PR DESCRIPTION
Closes #45.

**This PR needs to be squashed merged**
~~**This PR contains commits from #60 which needs to be merged first**~~ https://github.com/readthedocs-fr/bin/commit/e40681e49f8557060c6d4c2e82a759fa7c44d503
~~**This branch needs to be rebased)**~~

We need to discuss about the commit description and the commit name.

I propose `add: continuous integration` to be the commit name.
Commit description: 
```
This commit adds continuous integration, which allows us to 
validate tests on push, to build artifacts and docker image.

Artifacts and docker image building has been enabled only when 
pushing on the main branch, which avoid some useless computing
of GitHub machines, and users to use unstable versions of the 
service.

Test validation, on the other hand, is lightweight and therefore is 
enabled on each commit and pull request.

-----
Note from Tim about docker image building:
We choose Github Container Registry as Docker registry:
Github Packages for Containers is deprecated, and has some 
issues uploading images via Docker. Github Container Registry is 
in beta but should work fine here.

- CI to build Docker multi-arch images (arm64, arm/v6, arm/v7, amd64).
- Dockerfile edited to add a label to link the Github repository and GHCR
images.
- Inline some commands to lighten docker images.

* TODO: GHCR does not support GITHUB_TOKEN until now, we use a 
PAT (personal access token) and must be replaced as soon as possible.
-----

Another thing about the docker build thing: an account is dedicated to
docker image pushes (or to be more precise, his PAT is) on the 
organization, and is called readthedocker.
```