### PR TITLE
imp: add a language lexer unit test

### DIFF
--- a/tests/test_highlight.py
+++ b/tests/test_highlight.py
@@ -1,0 +1,16 @@
+import unittest
+import pygments
+from bin import utils
+
+class TestHighlight(unittest.TestCase):
+    @staticmethod
+    def has_language_formatter(lang):
+        try:
+            pygments.lexers.get_lexer_by_name(lang)
+            return True
+        except pygments.utils.ClassNotFound:
+            return False
+
+    def test_languages_has_formatter(self):
+        for lang in utils.languages:
+            self.assertTrue(self.has_language_formatter(lang[1]))


### PR DESCRIPTION
**This PR is required to be merged before #59**

Adds a new unit test, checking if languages list is valid by containing only languages for which pygments provides a lexer.

We need to test provided languages are covered by pygments lexers in order to:
- check if there is no spelling mistakes in the list
- be sure that it will not break the website by raising an exception if the language is not supported

The controller unit tests doesn't pass on my machine for some reason, we will know thanks to the CI if it passes in a correctly configured machine, or if it's broken like on my machine for some reason.

**Edit** 
- [X] The unit test will not pass for now on the CI anyway, because `pypi.drlazor.be` is down.
I'll need to rerun the CI in order to know, when it'll be up.

**Edit 2** 
- [X] I'll need to change commit description anyway, in order to avoid long lines, which are unreadable on CLI (I used GitHub Desktop to commit here, and so I forgot about it).