### PR TITLE
fix: unify license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Read The Docs
+Copyright (c) 2020 Read The Docs <opensource@readthedocs.fr>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This commit unify license over repositories of the organization.

In some repositories, author was "Read The Docs FR", on other it was "Read The Docs", and maybe some ones were also different.

The naming "Read The Docs" alone can be confusing with "Read The Docs, Inc." (readthedocs.org) and we don't want that.
That's why we appended to it a mailbox.

Now, the author will be "Read The Docs <opensource@readthedocs.fr>" all over the organization repositories.