### PR TITLE
imp: prevent bin overwriting

### DIFF
--- a/bin/controller.py
+++ b/bin/controller.py
@@ -52,10 +52,7 @@ def post_new():
     except ValueError as exc:
         raise bt.HTTPError(400, str(exc))
 
-    try:
-        snippet = models.Snippet.create(code, max(maxusage, 0), lifetime)
-    except RuntimeError as exc:
-        raise bt.HTTPError(500, str(exc))
+    snippet = models.Snippet.create(code, max(maxusage, 0), lifetime)
     bt.redirect(f'/{snippet.id}.{ext}')
 
 

--- a/bin/controller.py
+++ b/bin/controller.py
@@ -52,7 +52,10 @@ def post_new():
     except ValueError as exc:
         raise bt.HTTPError(400, str(exc))
 
-    snippet = models.Snippet.create(code, max(maxusage, 0), lifetime)
+    try:
+        snippet = models.Snippet.create(code, max(maxusage, 0), lifetime)
+    except RuntimeError as exc:
+        raise bt.HTTPError(500, str(exc))
     bt.redirect(f'/{snippet.id}.{ext}')
 
 

--- a/bin/models.py
+++ b/bin/models.py
@@ -14,9 +14,12 @@ class Snippet:
 
     @classmethod
     def create(cls, code, maxusage, lifetime):
-        ident = pronounceable_passwd(6)
-        while database.exists(ident):
+        for _ in range(20):
             ident = pronounceable_passwd(6)
+            if not database.exists(ident):
+                break
+        else:
+            raise RuntimeError("No free identifier has been found after 20 attempts")
         database.hset(ident, "code", code)
         database.hset(ident, "views_left", maxusage)
         if lifetime > 0:

--- a/bin/models.py
+++ b/bin/models.py
@@ -15,6 +15,8 @@ class Snippet:
     @classmethod
     def create(cls, code, maxusage, lifetime):
         ident = pronounceable_passwd(6)
+        while database.exists(ident):
+            ident = pronounceable_passwd(6)
         database.hset(ident, "code", code)
         database.hset(ident, "views_left", maxusage)
         if lifetime > 0:


### PR DESCRIPTION
Closes: #64.

A bin can currently overwrite another one, if it has the same identifier.
This will prevent overwriting, by generating an ID until it is not already taken.