### PR TITLE
ref: snippet revision plus global cleanup

### DIFF
--- a/bin/assets/scripts/newform.js
+++ b/bin/assets/scripts/newform.js
@@ -6,15 +6,13 @@ code.addEventListener('keydown', (event) => {
   if (event.code === 'Tab') {
     // prevents tab from being used to navigate between browser elements
     event.preventDefault();
-
-    const pos = code.selectionStart;
-    const content = code.value;
+    const { value, selectionStart, selectionEnd } = code;
 
     // inserts tab at the position of the caret
-    code.value = content.substring(0, pos) + '\t' + content.substring(pos);
+    code.value = value.slice(0, selectionStart) + '\t' + value.slice(selectionEnd);
 
     // puts caret after the newly inserted tab char
-    const caretPos = pos + 1;
+    const caretPos = selectionStart + 1;
     code.focus();
     code.setSelectionRange(caretPos, caretPos);
   }

--- a/bin/assets/styles/style.css
+++ b/bin/assets/styles/style.css
@@ -60,13 +60,13 @@ tr, td {
     content: attr(value);
 }
 
-.post-snippet {
+#post-snippet {
     padding: 0.3em 0 0.3em 0.6em;
     width: 100%;
     height: 100%;
 }
 
-.post-snippet textarea {
+#post-snippet textarea {
     background-color: transparent;
     border: none;
     resize: none;
@@ -115,26 +115,34 @@ input[type="number"] {
     -moz-appearance: textfield;
 }
 
-.controls button {
+.controls button, .controls a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    background-color: #5cbbf7;
+    cursor: pointer;
     border-radius: 50%;
     height: 4em;
     width: 4em;
-    transition: all 0.2s ease;
+    font: caption;
+    font-size: 0.85em;
+
+    transition: background-color 0.2s ease;
 }
 
-.post-snippet:valid .controls button {
-    background-color: #5cbbf7;
-    cursor: pointer;
-}
-
-.controls button svg {
-    fill: #707070;
-    height: 1.25em;
-    width: 1.25em;
-
-    transition: all 0.2s ease;
-}
-
-.post-snippet:valid .controls button svg {
+.controls button svg, .controls a svg {
     fill: #ffffff;
+    height: 1.75em;
+    width: 1.75em;
+    transition: background-color 0.2s ease;
+}
+
+#post-snippet:invalid .controls button {
+    background-color: #1d2529;
+    cursor: default;
+}
+
+#post-snippet:invalid .controls button svg {
+    fill: #707070;
 }

--- a/bin/config.py
+++ b/bin/config.py
@@ -21,6 +21,7 @@ load_dotenv(options.rtdbin_config)  # use a sensitive default when omitted
 HOST = os.getenv('RTDBIN_HOST', 'localhost')
 PORT = int(os.getenv('RTDBIN_PORT', options.rtdbin_port))
 MAXSIZE = Byte(os.getenv('RTDBIN_MAXSIZE', '16kiB'))
+IDENTSIZE = int(os.getenv('RTDBIN_IDENTSIZE', 6))
 DEFAULT_LANGUAGE = os.getenv('RTDBIN_DEFAULT_LANGUAGE', 'text')
 DEFAULT_MAXUSAGE = int(os.getenv('RTDBIN_DEFAULT_MAXUSAGE', 0))
 DEFAULT_LIFETIME = Time(os.getenv('RTDBIN_DEFAULT_LIFETIME', 0))

--- a/bin/views/highlight.html
+++ b/bin/views/highlight.html
@@ -10,7 +10,9 @@
         <div class="controls">
             % if parentid:
             <a class="control" title="Voir la révision précédente" href="/{{parentid}}.{{ext}}">
-                <!-- missing icon -->
+                <svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                    <path d="M4.6 2.6C5 2.2 5.5 2 6 2H10.6C11.1 2 11.6 2.2 12 2.6L15.4 6C15.8 6.4 16 6.9 16 7.4V16C16 16.5 15.8 17 15.4 17.4 15 17.8 14.5 18 14 18H6C5.5 18 5 17.8 4.6 17.4 4.2 17 4 16.5 4 16V4C4 3.5 4.2 3 4.6 2.6ZM9.7 7.3C9.5 7.1 9.3 7 9 7 8.7 7 8.5 7.1 8.3 7.3 8.1 7.5 8 7.7 8 8V12.7C8 12.9 8.1 13.1 8.2 13.2 8.3 13.4 8.4 13.5 8.6 13.6L12 14.9C12.2 15 12.5 15 12.7 14.9 12.9 14.8 13.1 14.6 13.2 14.4 13.3 14.1 13.3 13.8 13.2 13.6 13.1 13.4 12.9 13.2 12.7 13.1L10 12V8C10 7.7 9.9 7.5 9.7 7.3Z"/>
+                </svg>
             </a>
             % end
             <a class="control" title="Modifier" href="/?parentid={{snippetid}}&lang={{lang}}">
@@ -27,4 +29,3 @@
         </div>
     </body>
 </html>
-

--- a/bin/views/highlight.html
+++ b/bin/views/highlight.html
@@ -17,13 +17,13 @@
             % end
             <a class="control" title="Modifier" href="/?parentid={{snippetid}}&lang={{lang}}">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                  <path d="M9 2a2 2 0 00-2 2v8a2 2 0 002 2h6a2 2 0 002-2V6.414A2 2 0 0016.414 5L14 2.586A2 2 0 0012.586 2H9z" />
-                  <path d="M3 8a2 2 0 012-2v10h8a2 2 0 01-2 2H5a2 2 0 01-2-2V8z" />
+                    <path d="M9 2a2 2 0 00-2 2v8a2 2 0 002 2h6a2 2 0 002-2V6.414A2 2 0 0016.414 5L14 2.586A2 2 0 0012.586 2H9z" />
+                    <path d="M3 8a2 2 0 012-2v10h8a2 2 0 01-2 2H5a2 2 0 01-2-2V8z" />
                 </svg>
             </a>
             <a class="control" title="Nouveau" href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                  <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm5 6a1 1 0 10-2 0v2H7a1 1 0 100 2h2v2a1 1 0 102 0v-2h2a1 1 0 100-2h-2V8z" clip-rule="evenodd" />
+                    <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm5 6a1 1 0 10-2 0v2H7a1 1 0 100 2h2v2a1 1 0 102 0v-2h2a1 1 0 100-2h-2V8z" clip-rule="evenodd" />
                 </svg>
             </a>
         </div>

--- a/bin/views/highlight.html
+++ b/bin/views/highlight.html
@@ -7,5 +7,24 @@
     </head>
     <body>
 {{!codehl}}
+        <div class="controls">
+            % if parentid:
+            <a class="control" title="Voir la révision précédente" href="/{{parentid}}.{{ext}}">
+                <!-- missing icon -->
+            </a>
+            % end
+            <a class="control" title="Modifier" href="/?parentid={{snippetid}}&lang={{lang}}">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                  <path d="M9 2a2 2 0 00-2 2v8a2 2 0 002 2h6a2 2 0 002-2V6.414A2 2 0 0016.414 5L14 2.586A2 2 0 0012.586 2H9z" />
+                  <path d="M3 8a2 2 0 012-2v10h8a2 2 0 01-2 2H5a2 2 0 01-2-2V8z" />
+                </svg>
+            </a>
+            <a class="control" title="Nouveau" href="/">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                  <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm5 6a1 1 0 10-2 0v2H7a1 1 0 100 2h2v2a1 1 0 102 0v-2h2a1 1 0 100-2h-2V8z" clip-rule="evenodd" />
+                </svg>
+            </a>
+        </div>
     </body>
 </html>
+

--- a/bin/views/newform.html
+++ b/bin/views/newform.html
@@ -2,11 +2,12 @@
 <html lang=fr>
     <head>
         % include('head.html')
-        <script src="/assets/scripts/newform-button.js" defer></script>
+        <script src="/assets/scripts/newform.js" defer></script>
     </head>
     <body>
-        <form action="/new" method=POST class="post-snippet">
-            <textarea spellcheck=false placeholder="Entrer votre code." name=code autofocus required></textarea>
+        <form action="/new" method=POST id=post-snippet>
+            <textarea spellcheck=false placeholder="Entrer votre code." name=code autofocus required>{{code}}</textarea>
+            <input type=hidden name=parentid value="{{parentid}}">
 
             <div class="controls">
                 <input class="control" list=maxusage-presets type="number" min="0" title="Nombre d'utilisation maximum : 0 ou 10, ect." placeholder="Nombre d'utilisation maximum : 0 ou 10, ect." name=maxusage>
@@ -30,14 +31,17 @@
                 <select class="control" title="Langage" name=lang>
                     <option disabled>Langage</option>
                     % for ext, lang in languages:
-                    <option value="{{ext}}"{{' selected' if lang == default_language else ''}}>{{lang.title()}}</option>
+                    % if lang == default_language:
+                        <option value="{{ext}}" selected>{{lang.title()}}</option>
+                    % else:
+                        <option value="{{ext}}">{{lang.title()}}</option>
+                    % end
                     % end
                 </select>
 
-                <button class="control" title="Soumettre" type=submit>
+                <button class="control" title="Enregistrer" type=submit>
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                        <path d="M17.414 2.586a2 2 0 00-2.828 0L7 10.172V13h2.828l7.586-7.586a2 2 0 000-2.828z" />
-                        <path fill-rule="evenodd" d="M2 6a2 2 0 012-2h4a1 1 0 010 2H4v10h10v-4a1 1 0 112 0v4a2 2 0 01-2 2H4a2 2 0 01-2-2V6z" clip-rule="evenodd" />
+                      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm5 6a1 1 0 10-2 0v3.586l-1.293-1.293a1 1 0 10-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 11.586V8z" clip-rule="evenodd" />
                     </svg>
                 </button>
             </div>

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -10,9 +10,12 @@ from threading import Thread
 from unittest.mock import patch, MagicMock
 
 
-snippet_lipsum = Snippet(ident='lipsum', code="Lipsum", views_left=float('+inf'))
-snippet_python = Snippet(ident='egg', code='print("Hello world")', views_left=float('+inf'))
-snippet_htmlxss = Snippet(ident='htmlxss', code='<script>alert("XSS");</script>', views_left=float('+inf'))
+def make_snippet(ident, code):
+    return Snippet(ident=ident, code=code, views_left=float('+inf'), parentid='')
+
+snippet_lipsum = make_snippet('lipsum', code="Lorem ipsum dolor sit amet")
+snippet_python = make_snippet('egg', code='print("Hello world")')
+snippet_htmlxss = make_snippet('htmlxss', code='<script>alert("XSS");</script>')
 
 
 class HTMLSanitizer(HTMLParser):


### PR DESCRIPTION
Add the missing snippet revision feature, users can duplicate existing
snippets to edit them. The new snippet links its parent so it is easy to
compare them.

The `GET /` URL has been updated, it takes two optionnal query
parameters: (i) `lang` the language by default selected, it override the
config default. (ii) `parentid` the snippet to copy the code from.

The `POST /new` URL has been updated, it takes a form input `parentid`,
the original snippet the new one is a revision.

Additionnaly to the above feature, the source code have been scanned and
various minor changes have been made. In any order:

* The `newform-button.js` file has been renamed `newform.js`
* The `newform.html` <form> had a `post-snippet` class, it is now an id
* The various icons (save, new, dup, prev) share a common theme
* There is a new `RTDBIN_IDENTSIZE` option that control the length of
  the random snippet identifier. By default 6.
* The form `code` input is now utf-8 encoded (was latin-1)
* The backend form validation is stricter
* The `snippet_id` variable has been renamed `snippetid`
* The redis hset keys were the facto bytestring, it is now explicit
* There is a new function to ease snippet creating in the tests.

While they are not needed by themselves, it is a bit of house keeping
that is sure to be welcome by new contributers.

Co-authored-by: Mestery <48163546+Mesteery@users.noreply.github.com>
Co-authored-by: wyx0-xyz <wyxo.bs09@gmail.com>

Closes #10