### PR TITLE
fix: do not burn usage for discord bot

### DIFF
--- a/bin/controller.py
+++ b/bin/controller.py
@@ -4,10 +4,17 @@ Various HTTP routes the external world uses to communicate with the application.
 """
 
 import bottle as bt
+import re
 from pathlib import Path
 from metrics import Time
 from bin import root, config, models
 from bin.highlight import highlight, parse_language, parse_extension, languages
+
+
+BOTUARE = re.compile(r'|'.join([
+    re.escape('Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)'),
+    re.escape('facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)'),
+]))
 
 
 @bt.route('/health', method='GET')
@@ -120,6 +127,9 @@ def get_html(snippetid, ext=None):
 
     :raises HTTPError: code 404 when the snippet is not found
     """
+    if BOTUARE.match(bt.request.headers.get('User-Agent', '')):
+        return bt.template('blank.html')
+
     try:
         snippet = models.Snippet.get_by_id(snippetid)
     except KeyError:
@@ -145,6 +155,9 @@ def get_raw(snippetid, ext=None):
     :param snippetid: (path) required snippet id
     :param ext: (path) ignored parameter
     """
+    if BOTUARE.match(bt.request.headers.get('User-Agent', '')):
+        return bt.template('blank.html')
+
     try:
         snippet = models.Snippet.get_by_id(snippetid)
     except KeyError:

--- a/bin/views/blank.html
+++ b/bin/views/blank.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang=fr>
+<head>
+% include('head.html')
+</head>
+</html>


### PR DESCRIPTION
When we share a snippet on discord, discord does a free GET request to
generate a pretty embedded link. The thing is, it burns one usage every
time. We don't want discord burns an usage but we want to keep the
pretty embedded link.

We know look for the request User-Agent header, if discord is detected
we don't retrieve the snippet from the database and send a blank page
where only the `<head>` tag is filled. If a user is faking the
user-agent then he will only download a blank page.

Co-authored-by: Antoine James Tournepiche <antoinejt.serveur@gmail.com>

Closes #91
Closes #92 