### PR TITLE
Fix: controls boutons responsive design bug

### DIFF
--- a/bin/assets/styles/style.css
+++ b/bin/assets/styles/style.css
@@ -80,9 +80,8 @@ tr, td {
 }
 
 .controls {
-    position: absolute;
+    position: fixed;
     bottom: 0;
-    left: 0;
     right: 0;
     padding: 0 1.5em 1em 0.5em;
     pointer-events: none;


### PR DESCRIPTION
Les boutons de contrôle se trouvaient au milieu de la page notamment sur la version mobile:
Avant:
![image](https://user-images.githubusercontent.com/60854021/107771370-f328cc00-6d3a-11eb-939e-3d8b534b6d74.png)
Après:
![image](https://user-images.githubusercontent.com/60854021/107771386-f9b74380-6d3a-11eb-9734-a52dc73cd6c4.png)
_(La coloration syntaxique sera bien présente après la PR)_