### PR TITLE
fix: form buttons were sticking in place

### DIFF
--- a/bin/assets/styles/style.css
+++ b/bin/assets/styles/style.css
@@ -80,9 +80,8 @@ tr, td {
 }
 
 .controls {
-    position: absolute;
+    position: fixed;
     bottom: 0;
-    left: 0;
     right: 0;
     padding: 0 1.5em 1em 0.5em;
     pointer-events: none;


### PR DESCRIPTION
Save a pretty long code snippet, long enough you need to scroll the page
to see it entirely. When you scroll down, the few buttons (duplicate, new,
previous revision) don't stay in the bottom left corner but instead scroll
too. They should stick on the bottom right corner.

Closes #95
Closes #96 