### PR TITLE
fix: encoding issues

### DIFF
--- a/bin/views/head.html
+++ b/bin/views/head.html
@@ -1,4 +1,5 @@
 <meta charset=utf-8>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 <title>ReadTheDocs - bin</title>
 
 <meta name=viewport content="width=device-width, initial-scale=1.0">

--- a/bin/views/newform.html
+++ b/bin/views/newform.html
@@ -5,7 +5,7 @@
         <script src="/assets/scripts/newform.js" defer></script>
     </head>
     <body>
-        <form action="/new" method=POST id=post-snippet enctype="multipart/form-data" accept-charset=utf-8>
+        <form action="/new" method=POST id=post-snippet accept-charset=utf-8>
             <textarea spellcheck=false placeholder="Entrer votre code." name=code autofocus required>{{code}}</textarea>
             <input type=hidden name=parentid value="{{parentid}}">
 

--- a/bin/views/newform.html
+++ b/bin/views/newform.html
@@ -5,7 +5,7 @@
         <script src="/assets/scripts/newform.js" defer></script>
     </head>
     <body>
-        <form action="/new" method=POST id=post-snippet>
+        <form action="/new" method=POST id=post-snippet enctype="multipart/form-data" accept-charset=utf-8>
             <textarea spellcheck=false placeholder="Entrer votre code." name=code autofocus required>{{code}}</textarea>
             <input type=hidden name=parentid value="{{parentid}}">
 


### PR DESCRIPTION
When creating a bin, via the browser, encoding problems occurred.
Indeed, the browser did not send the form in utf8, but in probably another encoding.
This could cause encoding problems, especially on the display.

To solve this problem, the use of a form-data accompanied by
an charset-accept and a http-equiv ContentType proved to be efficient.

Closes: #100.