### PR TITLE
fix: wrong form encoding

### DIFF
--- a/bin/controller.py
+++ b/bin/controller.py
@@ -4,6 +4,7 @@ Various HTTP routes the external world uses to communicate with the application.
 """
 
 import bottle as bt
+import quopri
 import re
 from pathlib import Path
 from metrics import Time
@@ -92,7 +93,7 @@ def post_new():
             code = part.file.read(config.MAXSIZE)
             ext = parse_extension(Path(part.filename).suffix.lstrip('.')) or ext
         if forms:
-            code = forms.get('code', '').encode('utf-8') or code
+            code = quopri.decodestring(forms.get('code', '').encode('latin-1')) or code
             ext = parse_extension(forms.get('lang')) or ext
             maxusage = int(forms.get('maxusage') or maxusage)
             lifetime = Time(forms.get('lifetime') or lifetime)

--- a/bin/views/head.html
+++ b/bin/views/head.html
@@ -1,4 +1,5 @@
 <meta charset=utf-8>
+<meta http-equiv=content-type content="text/html;charset=utf-8">
 <title>ReadTheDocs - bin</title>
 
 <meta name=viewport content="width=device-width, initial-scale=1.0">

--- a/bin/views/newform.html
+++ b/bin/views/newform.html
@@ -5,7 +5,7 @@
         <script src="/assets/scripts/newform.js" defer></script>
     </head>
     <body>
-        <form action="/new" method=POST id=post-snippet>
+        <form action="/new" method=POST id=post-snippet accept-charset=utf-8>
             <textarea spellcheck=false placeholder="Entrer votre code." name=code autofocus required>{{code}}</textarea>
             <input type=hidden name=parentid value="{{parentid}}">
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3,11 +3,14 @@ import html
 import re
 import unittest
 import urllib.request as urlreq
+import socket
 from bin.models import Snippet
 from bottle import template as bottle_template
 from html.parser import HTMLParser
+from textwrap import dedent
 from threading import Thread
 from unittest.mock import patch, MagicMock
+from genpw import pronounceable_passwd as ppwd
 
 
 def make_snippet(ident, code):
@@ -17,10 +20,29 @@ snippet_lipsum = make_snippet('lipsum', code="Lorem ipsum dolor sit amet")
 snippet_python = make_snippet('egg', code='print("Hello world")')
 snippet_htmlxss = make_snippet('htmlxss', code='<script>alert("XSS");</script>')
 snippet_classified = make_snippet('classified', code='T_xJV3P^FcvYijzH')
+snippet_utf8 = make_snippet('utf8', code='éèùÈÇ')
 
 UA_HUMAN = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:85.0) Gecko/20100101 Firefox/85.0"
 UA_BOT = "Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)"
 
+class FakeSnippet(Snippet):
+    snippets = {}
+    last_snippet = None
+
+    @classmethod
+    def create(cls, code, maxusage, lifetime, parentid):
+        ident = ppwd(6)
+        snippet = cls(ident, code, maxusage, parentid)
+        cls.snippets[ident] = cls.last_snippet = snippet
+        return snippet
+
+    @classmethod
+    def get_by_id(cls, ident):
+        snippet = cls.snippets[ident]
+        snippet.view_left -= 1
+        if snippet.view_left == 0:
+            del cls.snippets[snippet]
+        return snippet
 
 class HTMLSanitizer(HTMLParser):
     def __init__(self, testcase):
@@ -217,3 +239,58 @@ class TestController(unittest.TestCase):
             with urlreq.urlopen(req) as res:
                 MockSnippet.get_by_id.assert_called()
                 self.assertEqual(res.status, 200)
+
+    def test_unicode(self):
+        russian_text = (
+            "В колониальные времена территория, занятая ныне Ист-Виллиджем, "
+            "была окраиной Нью-Йорка."
+        )
+
+        with patch('bin.models.Snippet') as MockSnippet:
+            MockSnippet.create.side_effect = FakeSnippet.create
+            MockSnippet.get_by_id.side_effeft = FakeSnippet.get_by_id
+
+            with self.subTest(agent='curl/7.64.0'):
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.connect(('127.0.0.1', 8012))
+                # $ curl localhost:8012 -X POST -d "code=В колониальные..."
+                sock.send(dedent(b"""\
+                    POST /new HTTP/1.1
+                    Host: localhost:8012
+                    User-Agent: curl/7.64.0
+                    Accept: */*
+                    Content-Length: 165
+                    Content-Type: application/x-www-form-urlencoded
+
+                    code=\xd0\x92 \xd0\xba\xd0\xbe\xd0\xbb\xd0\xbe\xd0\xbd\xd0\xb8\xd0\xb0\xd0\xbb\xd1\x8c\xd0\xbd\xd1\x8b\xd0\xb5 \xd0\xb2\xd1\x80\xd0\xb5\xd0\xbc\xd0\xb5\xd0\xbd\xd0\xb0 \xd1\x82\xd0\xb5\xd1\x80\xd1\x80\xd0\xb8\xd1\x82\xd0\xbe\xd1\x80\xd0\xb8\xd1\x8f, \xd0\xb7\xd0\xb0\xd0\xbd\xd1\x8f\xd1\x82\xd0\xb0\xd1\x8f \xd0\xbd\xd1\x8b\xd0\xbd\xd0\xb5 \xd0\x98\xd1\x81\xd1\x82-\xd0\x92\xd0\xb8\xd0\xbb\xd0\xbb\xd0\xb8\xd0\xb4\xd0\xb6\xd0\xb5\xd0\xbc, \xd0\xb1\xd1\x8b\xd0\xbb\xd0\xb0 \xd0\xbe\xd0\xba\xd1\x80\xd0\xb0\xd0\xb8\xd0\xbd\xd0\xbe\xd0\xb9 \xd0\x9d\xd1\x8c\xd1\x8e-\xd0\x99\xd0\xbe\xd1\x80\xd0\xba\xd0\xb0.""".decode('latin-1')).encode('latin-1'))
+
+                resp = sock.recv(1024)
+                sock.close()
+                self.assertEqual(resp.partition(b"\r\n")[0], b"HTTP/1.0 303 See Other")
+                self.assertEqual(FakeSnippet.last_snippet.code, russian_text.encode('utf-8'))
+
+            with self.subTest(agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:85.0) Gecko/20100101 Firefox/85.0'):
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.connect(('127.0.0.1', 8012))
+                sock.send(dedent(b"""\
+                    POST /new HTTP/1.1
+                    Host: localhost:8012
+                    User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:85.0) Gecko/20100101 Firefox/85.0
+                    Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+                    Accept-Language: en-US,fr;q=0.8,fr-FR;q=0.5,en;q=0.3
+                    Accept-Encoding: gzip, deflate
+                    Content-Type: application/x-www-form-urlencoded
+                    Content-Length: 500
+                    Origin: http://localhost:8012
+                    DNT: 1
+                    Connection: keep-alive
+                    Referer: http://localhost:8012/
+                    Upgrade-Insecure-Requests: 1
+                    Sec-GPC: 1
+
+                    code=%D0%92+%D0%BA%D0%BE%D0%BB%D0%BE%D0%BD%D0%B8%D0%B0%D0%BB%D1%8C%D0%BD%D1%8B%D0%B5+%D0%B2%D1%80%D0%B5%D0%BC%D0%B5%D0%BD%D0%B0+%D1%82%D0%B5%D1%80%D1%80%D0%B8%D1%82%D0%BE%D1%80%D0%B8%D1%8F%2C+%D0%B7%D0%B0%D0%BD%D1%8F%D1%82%D0%B0%D1%8F+%D0%BD%D1%8B%D0%BD%D0%B5+%D0%98%D1%81%D1%82-%D0%92%D0%B8%D0%BB%D0%BB%D0%B8%D0%B4%D0%B6%D0%B5%D0%BC%2C+%D0%B1%D1%8B%D0%BB%D0%B0+%D0%BE%D0%BA%D1%80%D0%B0%D0%B8%D0%BD%D0%BE%D0%B9+%D0%9D%D1%8C%D1%8E-%D0%99%D0%BE%D1%80%D0%BA%D0%B0.&parentid=&maxusage=&lifetime=&lang=txt""".decode('latin-1')).encode('latin-1'))
+
+                resp = sock.recv(1024)
+                sock.close()
+                self.assertEqual(resp.partition(b"\r\n")[0], b"HTTP/1.0 303 See Other")
+                self.assertEqual(FakeSnippet.last_snippet.code, russian_text.encode('utf-8'))


### PR DESCRIPTION
Save a snippet that contains non-ascii characters, the characters are
not displayed correctly.

Posting a form using `x-www-form-urlencoded` requires the form to be
Quoted-Printable encoded (see [rfc2045] section 6.7), most agents
conform to the rfc except curl that just send the form as-is.

When bottle receives the data, that scumbag piece of shit thinks he is
more clever than anyone and just decodes the form using the latin-1
encoding without any consideration for internet standards. This commit
undoes the latin-1 bullshit to restore utf8 and decodes any
printed-quotable left.

You want valid encoding ? Use multi-part and utf-8.

rfc2045: https://tools.ietf.org/html/rfc2045#section-6.7

Closes #100
Closes #101