### PR TITLE
imp: improve front responsivity

### DIFF
--- a/bin/assets/styles/style.css
+++ b/bin/assets/styles/style.css
@@ -30,7 +30,6 @@ body {
     border-spacing: 0;
     border-collapse: separate;
     display: flex;
-    flex-flow: wrap row;
     overflow-x: scroll;
 }
 

--- a/bin/assets/styles/style.css
+++ b/bin/assets/styles/style.css
@@ -22,16 +22,19 @@ body {
 }
 
 .highlight {
+    height: 100%;
     padding: 1em 0.6em 1em 0;
     background: transparent !important;
     font-family: Consolas, monospace;
     font-size: 1em;
-    overflow-x: scroll;
     border-spacing: 0;
     border-collapse: separate;
+    display: flex;
+    flex-flow: wrap row;
+    overflow-x: scroll;
 }
 
-tr, td {
+.highlight tr, td {
     vertical-align: baseline;
     white-space: pre;
 }
@@ -46,14 +49,15 @@ tr, td {
 
 .line-number {
     width: 1%;
-    min-width: 2em;
-    padding: 0 0.65em;
+    min-width: 1em;
+    padding: 0 0.5em;
     text-align: right;
     font-family: Consolas, monospace;
     cursor: pointer;
     user-select: none;
     -webkit-user-select: none;
     -moz-user-select: none;
+    -webkit-tap-highlight-color: transparent;
 }
 
 .line-number::before {
@@ -83,7 +87,7 @@ tr, td {
     position: fixed;
     bottom: 0;
     right: 0;
-    padding: 0 1.5em 1em 0.5em;
+    padding: 0.7em;
     pointer-events: none;
     display: flex;
     align-items: center;


### PR DESCRIPTION
The responsiveness of the interface has been drastically improved.
Especially on small screens, the page was not responsive
when the code of the snippet overflow horizontally.

The `table` was put in flex display to solve this problem.
It comes with an overflow scroll and a 100% height
to be able to scroll everywhere.
Some other properties have also been adjusted,
such as the padding on the parent of the control buttons.

Closes: https://github.com/readthedocs-fr/bin-server/issues/77.