### PR TITLE
add: file drag n drop

### DIFF
--- a/bin/assets/scripts/newform.js
+++ b/bin/assets/scripts/newform.js
@@ -1,5 +1,18 @@
 const form = document.forms[0];
+const lang = form.lang;
+const langs = [...lang.options].slice(1).flatMap((option) => [option.value, option.textContent.toLowerCase()]);
 const code = form.code;
+
+const additionalLangs = {
+  txt: langs.indexOf('txt'),
+  svg: langs.indexOf('xml'),
+  jsonc: langs.indexOf('js'),
+  get jsx() {
+    return this.jsonc;
+  },
+  tsx: langs.indexOf('ts'),
+  vue: langs.indexOf('html'),
+}
 
 // remove the "required" error message that overflows the page
 code.addEventListener('invalid', (event) => event.preventDefault());
@@ -21,4 +34,25 @@ code.addEventListener('keydown', (event) => {
     event.preventDefault();
     form.submit();
   }
+});
+
+window.addEventListener('drop', async (event) => {
+  const files = event.dataTransfer.files;
+  if (files.length !== 1) {
+    return;
+  }
+
+  event.preventDefault();
+  const file = files[0];
+  const fileExtension = file.name.split('.').pop()?.toLowerCase() ?? '';
+
+  const langIndex = additionalLangs[fileExtension] ?? langs.indexOf(fileExtension);
+  if (langIndex === -1 && !confirm("Ce fichier n'est pas dans la liste des langages, voulez-vous quand même le charger ?")) {
+    return;
+  }
+
+  try {=
+    code.value = await file.text();
+    lang.selectedIndex = Math.ceil((langIndex === -1 ? additionalLangs.txt : langIndex) / 2) + 1;
+  } catch (error) {} // the "file" is a directory (do nothing)
 });

--- a/bin/assets/scripts/newform.js
+++ b/bin/assets/scripts/newform.js
@@ -3,7 +3,7 @@ const lang = form.lang;
 const langs = [...lang.options].slice(1).flatMap((option) => [option.value, option.textContent.toLowerCase()]);
 const code = form.code;
 
-const additionalLangs = {
+const langAliases = {
   txt: langs.indexOf('txt'),
   svg: langs.indexOf('xml'),
   jsonc: langs.indexOf('js'),
@@ -46,13 +46,13 @@ window.addEventListener('drop', async (event) => {
   const file = files[0];
   const fileExtension = file.name.split('.').pop()?.toLowerCase() ?? '';
 
-  const langIndex = additionalLangs[fileExtension] ?? langs.indexOf(fileExtension);
+  const langIndex = langAliases[fileExtension] ?? langs.indexOf(fileExtension);
   if (langIndex === -1 && !confirm("Ce fichier n'est pas dans la liste des langages, voulez-vous quand même le charger ?")) {
     return;
   }
 
-  try {=
+  try {
     code.value = await file.text();
-    lang.selectedIndex = Math.ceil((langIndex === -1 ? additionalLangs.txt : langIndex) / 2) + 1;
+    lang.selectedIndex = Math.ceil((langIndex === -1 ? langAliases.txt : langIndex) / 2) + 1;
   } catch (error) {} // the "file" is a directory (do nothing)
 });

--- a/bin/views/newform.html
+++ b/bin/views/newform.html
@@ -6,7 +6,7 @@
     </head>
     <body>
         <form action="/new" method=POST id=post-snippet accept-charset=utf-8>
-            <textarea spellcheck=false placeholder="Entrer votre code." name=code autofocus required>{{code}}</textarea>
+            <textarea spellcheck=false placeholder="Entrez votre code ou glissez un fichier." name=code autofocus required>{{code}}</textarea>
             <input type=hidden name=parentid value="{{parentid}}">
 
             <div class="controls">


### PR DESCRIPTION
Now a file can be dropped on the bin.

If only one file (with a supported language) is dropped,
its content appears immediately in the textarea.
The language is automatically chosen.

If the format of this file does not seem to be supported,
a confirmation is displayed, asking if it should be loaded, or not.
If the user confirms, the content of the file (whether binary or not)
is put in the textarea, with "txt" as language.

If multiple files or folders are selected,
the default behavior of the browser is kept (only in some cases).

Note that in some cases the browser forces its default behavior,
for example when an executable is dropped.