### PR TITLE
imp: tag docker image for version

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - main
+    tags:
+    - 'v*'
 
 jobs:
   docker:
@@ -19,6 +21,9 @@ jobs:
         with:
           images: ghcr.io/readthedocs-fr/bin
           tag-sha: true
+          tag-semver: |
+            {{version}}
+            {{major}}.{{minor}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
Depuis le passage à la v1, nous devrions tag les images docker correspondantes à leur version. 
Cette PR vient ajouter ce comportement en se basant sur l'ajout de tag (sur main) au format SemVer.

Ainsi lors de l'ajout d'un tag comme `v1.0.2`, l'image docker associée sera tag comme `bin:1.0.2` et `bin:1.0`.
Bien sûr cela ne remplace pas le comportement déjà défini, les images sont toujours associées au sha-id des commits (version courte) et tag comme `latest` s'il s'agit du dernier commit sur main.

Par ailleurs, est-il nécessaire de changer la version pour ce commit, vu qu'il ne change rien au bin en lui-même ?
Si oui, je suppose qu'incrémenter `patch` sera suffisant.