### PR TITLE
add: bin deletion

### DIFF
--- a/bin/assets/scripts/delete.js
+++ b/bin/assets/scripts/delete.js
@@ -1,0 +1,32 @@
+const deleteButton = document.getElementById('delete-button');
+const token = new URLSearchParams(location.search).get('token');
+
+if (token) {
+  deleteButton.removeAttribute('hidden');
+  deleteButton.addEventListener('click', async () => {
+    try {
+      const response = await fetch(window.location.pathname, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Token ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        const error = new Error(`${response.status} ${response.statusText}\n${await response.text()}`);
+        error.response = response;
+        throw error;
+      }
+
+      location.href = '/';
+    } catch (error) {
+      console.error(error);
+      if (error.response.status === 401) {
+        alert("Le token que vous avez fourni est très probablement erroné.");
+      } else {
+        console.error("Nous vous recommandons d'ouvrir une issue sur https://github.com/readthedocs-fr/bin-server si le problème persiste.");
+        alert(`Une erreur est survenue (${error.response?.statusText || error.message}), votre snippet n'a donc pas pu être supprimé. Regardez la console pour plus d'informations.`);
+      }
+    }
+  });
+}

--- a/bin/assets/scripts/loc.js
+++ b/bin/assets/scripts/loc.js
@@ -4,7 +4,7 @@ const selectedLocs = document.getElementsByClassName('selected');
 handleHash();
 
 window.addEventListener('hashchange', () => {
-  [...selectedLocs].forEach((e) => e.classList.remove('selected'));
+  clearSelections();
   handleHash();
 })
 
@@ -12,35 +12,39 @@ locs.forEach((loc, i) => {
   loc.addEventListener('click', () => {
     // add the line location to the URL without affecting the history and without triggering a hashchange
     window.history.replaceState(undefined, undefined, `#L${i + 1}`);
-    // remove all selected lines
-    [...selectedLocs].forEach((e) => e.classList.remove('selected'));
+    clearSelections();
     loc.nextElementSibling.classList.add('selected');
   })
 })
 
+function clearSelections() {
+  [...selectedLocs].forEach((element) => element.classList.remove('selected'));
+}
+
 function handleHash() {
-  const hashMatch = location.hash.match(/^(?:#L(\d+)(?:-L(\d+))?)$/i);
+  const hashMatch = location.hash.match(/^#L(\d+)(?:-L(\d+))?$/i);
   if (!hashMatch) {
     return;
   }
-  let start = parseInt(hashMatch[1], 10);
-  let end = hashMatch[2] ? parseInt(hashMatch[2], 10) : undefined;
+
+  let start = +hashMatch[1];
+  let end = hashMatch[2] ? +hashMatch[2] : undefined;
   if (end && start > end) {
     [start, end] = [end, start];
   }
-  if (start <= 0 || start > locs.length || end && end <= 0 || end > locs.length) {
+  if (start <= 0 || start > locs.length || end && (end <= 0 || end > locs.length)) {
     return;
   }
-  if (!end) {
-    locs[start - 1].nextElementSibling.classList.add('selected');
+
+  locs[start - 1].nextElementSibling.classList.add('selected');
+
+  if (!end || start === end) {
     return;
   }
-  for (let i = start - 1; i <= locs.length && i < end; i++) {
-    const line = locs[i].nextElementSibling;
-    line.classList.add('selected');
-    if (i === start - 1) {
-      // scroll to the first line of the selection
-      line.scrollIntoView();
-    }
+
+  // scroll to the first line of the selection
+  locs[start - 1].nextElementSibling.scrollIntoView();
+  for (let i = start; i < end; i++) {
+    locs[i].nextElementSibling.classList.add('selected');
   }
 }

--- a/bin/assets/scripts/loc.js
+++ b/bin/assets/scripts/loc.js
@@ -2,6 +2,7 @@ const locs = [...document.getElementsByClassName('line-number')];
 const selectedLocs = document.getElementsByClassName('selected');
 
 handleHash();
+
 window.addEventListener('hashchange', () => {
   [...selectedLocs].forEach((e) => e.classList.remove('selected'));
   handleHash();

--- a/bin/assets/scripts/newform.js
+++ b/bin/assets/scripts/newform.js
@@ -2,6 +2,15 @@ const form = document.forms['post-snippet'];
 const lang = form.lang;
 const langs = [...lang.options].slice(1).flatMap((option) => [option.value, option.textContent.toLowerCase()]);
 const code = form.code;
+const token = form.token;
+
+token.addEventListener('click', () => {
+  navigator.clipboard.writeText(token.value).catch(() => {
+    // fallback to execCommand copy method
+    token.value.select();
+    document.execCommand('copy');
+  });
+})
 
 const langAliases = {
   txt: langs.indexOf('txt'),

--- a/bin/assets/scripts/newform.js
+++ b/bin/assets/scripts/newform.js
@@ -32,7 +32,7 @@ code.addEventListener('keydown', (event) => {
     const { value, selectionStart, selectionEnd } = code;
 
     // inserts tab at the position of the caret
-    code.value = value.slice(0, selectionStart) + '\t' + value.slice(selectionEnd);
+    code.value = `${value.slice(0, selectionStart)}\t${value.slice(selectionEnd)}`;
 
     // puts caret after the newly inserted tab char
     const caretPos = selectionStart + 1;

--- a/bin/controller.py
+++ b/bin/controller.py
@@ -74,10 +74,10 @@ def post_new():
     for the snippet.
 
     :param code: (form) required snippet text, can alternativaly be sent as a Multi-Part utf-8 file
-    :param lang: (form) optionnal language
-    :param maxusage: (form) optionnal maximum download of the snippet before it is deleted
-    :param lifetime: (form) optionnal time (defined in seconds) the snippet is keep in the database before it is deleted
-    :param parentid: (form) optionnal snippet id this new snippet is a duplicate of
+    :param lang: (form) optional language
+    :param maxusage: (form) optional maximum download of the snippet before it is deleted
+    :param lifetime: (form) optional time (defined in seconds) the snippet is keep in the database before it is deleted
+    :param parentid: (form) optional snippet id this new snippet is a duplicate of
     :param token: (form) optional the "admin" token allows you to delete your snippet
 
     :raises HTTPError: code 411 when the ``Content-Length`` http header is missing

--- a/bin/views/highlight.html
+++ b/bin/views/highlight.html
@@ -6,6 +6,7 @@
         <link rel=stylesheet href="/assets/styles/monokai.css">
         <script src="/assets/scripts/loc.js" defer></script>
         <script src="/assets/scripts/report.js" defer></script>
+        <script src="/assets/scripts/delete.js" defer></script>
     </head>
     <body>
 {{!codehl}}
@@ -22,6 +23,14 @@
         </form>
 
         <div class="controls">
+            % if token:
+            <button class="control" id=delete-button title="Supprimer le snippet" hidden>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                    <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm1 8a1 1 0 100 2h6a1 1 0 100-2H7z" clip-rule="evenodd" />
+                </svg>
+            </button>
+            % end
+
             % if parentid:
             <a class="control" title="Voir la révision précédente" href="/{{parentid}}.{{ext}}">
                 <svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" fill="currentColor">

--- a/bin/views/newform.html
+++ b/bin/views/newform.html
@@ -10,6 +10,8 @@
             <input type=hidden name=parentid value="{{parentid}}">
 
             <div class="controls">
+                <input name=token class="control" title="Cliquez pour copier. Ce token vous permet de supprimer votre snippet à tout moment (e.g. /turick.ts?token=aUiJR4593)." value="{{token}}" readonly>
+                
                 <input class="control" list=maxusage-presets type="number" min="0" title="Nombre d'utilisation maximum : 0 ou 10, ect." placeholder="Nombre d'utilisation maximum : 0 ou 10, ect." name=maxusage>
                 <datalist id=maxusage-presets>
                     <option value="0">

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,6 +1,4 @@
 import bottle
-import html
-import re
 import unittest
 import urllib.request as urlreq
 from urllib.error import HTTPError
@@ -12,7 +10,7 @@ from unittest.mock import patch, MagicMock
 
 
 def make_snippet(ident, code):
-    return Snippet(ident=ident, code=code, views_left=float('+inf'), parentid='')
+    return Snippet(ident=ident, code=code, views_left=float('+inf'), parentid='', token=None)
 
 snippet_lipsum = make_snippet('lipsum', code="Lorem ipsum dolor sit amet")
 snippet_python = make_snippet('egg', code='print("Hello world")')


### PR DESCRIPTION
It is now possible to delete his snippet by providing a token.
This token is provided by the controller.
The snippet can be removed via a request `DELETE /<id>`
with the header `Authorization: Token <ADMIN_TOKEN>`.
The front calls this route when the user clicks on the delete button
(if the correct token is provided via a query (`/<id>?token=<ADMIN_TOKEN>`)).

Some scripts (js) have been refactorized.