### PR TITLE
Some fixes...

### DIFF
--- a/bin/controller.py
+++ b/bin/controller.py
@@ -38,7 +38,7 @@ def get_new_form():
     lang = bt.request.query.lang or config.DEFAULT_LANGUAGE
 
     try:
-        code = models.Snippet.get_by_id(parentid) if parentid else ""
+        code = models.Snippet.get_by_id(parentid).code if parentid else ""
     except KeyError:
         raise bt.HTTPError(404, "Parent snippet not found")
 

--- a/bin/controller.py
+++ b/bin/controller.py
@@ -89,7 +89,7 @@ def post_new():
     forms = bt.request.forms
 
     code = None
-    ext = parse_extension(config.DEFAULT_LANGUAGE)
+    lang = config.DEFAULT_LANGUAGE
     maxusage = config.DEFAULT_MAXUSAGE
     lifetime = config.DEFAULT_LIFETIME
     parentid = ''
@@ -99,15 +99,16 @@ def post_new():
             part = next(files.values())
             charset = cgi.parse_header(part.content_type)[1].get('charset', 'utf-8')
             code = part.file.read(config.MAXSIZE).decode(charset)
-            ext = parse_extension(Path(part.filename).suffix.lstrip('.')) or ext
+            lang = parse_extension(Path(part.filename).suffix.lstrip('.')) or lang
         if forms:
             # WSGI forces latin-1 decoding, this is wrong, we recode it in utf-8
             code = forms.get('code', '').encode('latin-1').decode() or code
-            ext = parse_extension(forms.get('lang')) or ext
+            lang = forms.get('lang') or lang
             maxusage = int(forms.get('maxusage') or maxusage)
             lifetime = Time(forms.get('lifetime') or lifetime)
             parentid = forms.get('parentid', '')
 
+        ext = parse_language(lang)
         if not code:
             raise ValueError("Code is missing")
         if maxusage < 0:

--- a/bin/highlight.py
+++ b/bin/highlight.py
@@ -7,6 +7,7 @@ from pygments.formatters.html import HtmlFormatter
 
 
 languages = [
+    # (ext, lang)
     ('c', 'c'),
     ('cpp', 'cpp'),
     ('cs', 'csharp'),
@@ -44,24 +45,24 @@ languages = [
     ('xml', 'xml'),
     ('yml', 'yaml'),
 ]
-exttolang = {ext: language for ext, language in languages}
-langtoext = {language: ext for ext, language in languages}
+exttolang = {ext: lang for ext, lang in languages}
+langtoext = {lang: ext for ext, lang in languages}
 
 
-def parse_extension(lang_or_ext):
-    """ From a language name or a language extension, get a language """
-    lang_or_ext = (lang_or_ext or '').casefold()
-    if lang_or_ext in exttolang:
-        return lang_or_ext
-    return langtoext.get(lang_or_ext)
+def parse_extension(ext):
+    """ From a language extension, get a language """
+    ext = (ext or '').casefold()
+    if ext in langtoext:
+        return ext  # this is a lang already
+    return exttolang.get(ext)
 
 
-def parse_language(lang_or_ext):
-    """ From a language name or a language extension, get an extension """
-    lang_or_ext = (lang_or_ext or '').casefold()
-    if lang_or_ext in langtoext:
-        return lang_or_ext
-    return exttolang.get(lang_or_ext)
+def parse_language(lang):
+    """ From a language name, get an extension """
+    lang = (lang or '').casefold()
+    if lang in exttolang:
+        return lang  # this is an ext already
+    return langtoext.get(lang)
 
 
 

--- a/bin/models.py
+++ b/bin/models.py
@@ -27,6 +27,20 @@ class Snippet:
         self.parentid = parentid  #: the original snippet this one is a duplicate of or an empty string
 
     @classmethod
+    def new_id(cls):
+        """ Generate a safe unique identifier """
+        for _ in range(20):
+            ident = pronounceable_passwd(config.IDENTSIZE)
+            if database.exists(ident):
+                continue
+            if ident in {'health', 'assets', 'new', 'raw'}:
+                continue
+            return ident
+
+        raise RuntimeError("No free identifier has been found after 20 attempts")
+
+
+    @classmethod
     def create(cls, code, maxusage, lifetime, parentid):
         """
         Save a snippet in the database and return a snippet object
@@ -36,12 +50,7 @@ class Snippet:
         :param lifetime: how long the snippet is saved before self-deletion
         :param parentid: the original snippet id this new snippet is a duplicate of, empty string for original snippet
         """
-        for _ in range(20):
-            ident = pronounceable_passwd(config.IDENTSIZE)
-            if not database.exists(ident):
-                break
-        else:
-            raise RuntimeError("No free identifier has been found after 20 attempts")
+        ident = cls.new_id()
         database.hset(ident, b'code', code)
         database.hset(ident, b'views_left', maxusage)
         database.hset(ident, b'parentid', parentid)

--- a/bin/views/newform.html
+++ b/bin/views/newform.html
@@ -30,11 +30,11 @@
 
                 <select class="control" title="Langage" name=lang>
                     <option disabled>Langage</option>
-                    % for ext, lang in languages:
+                    % for _, lang in languages:
                     % if lang == default_language:
-                        <option value="{{ext}}" selected>{{lang.title()}}</option>
+                        <option value="{{lang}}" selected>{{lang.title()}}</option>
                     % else:
-                        <option value="{{ext}}">{{lang.title()}}</option>
+                        <option value="{{lang}}">{{lang.title()}}</option>
                     % end
                     % end
                 </select>


### PR DESCRIPTION
**fix: prevent generated id to override with routes**

There are some routes that are 6 characters long (`health` and `assets`)
that could be overridden by the generated snippet identifier.

**fix: lang and extension parsing**

The code converting lang and extension back and forth was confusing and
resulted in incoherent parsing. The docstrings and implementations were
clashing with one another.

**fix: snippet duplication typo**

Duplicate a snippet, you get `repr(snippet)` instead of `snippet.code`

Fine tuning of ba2aa243641
