### PR TITLE
Logging and reporting

### DIFF
--- a/bin/assets/scripts/newform.js
+++ b/bin/assets/scripts/newform.js
@@ -1,4 +1,4 @@
-const form = document.forms[0];
+const form = document.forms['post-snippet'];
 const lang = form.lang;
 const langs = [...lang.options].slice(1).flatMap((option) => [option.value, option.textContent.toLowerCase()]);
 const code = form.code;

--- a/bin/assets/scripts/report.js
+++ b/bin/assets/scripts/report.js
@@ -1,0 +1,17 @@
+const promptMessage = `\
+Vous allez signaler ce snippet auprès de l'administrateur.
+Tout abus peut mener à la coupure du service.
+
+Veuillez entrer votre nom ou votre adresse email :`;
+
+const reportForm = document.forms.report;
+reportForm.addEventListener('submit', (event) => {
+  const name = prompt(promptMessage)?.trim();
+
+  if (!name?.length) {
+    event.preventDefault();
+    return;
+  }
+
+  reportForm.name.value = name;
+});

--- a/bin/assets/styles/report.css
+++ b/bin/assets/styles/report.css
@@ -1,0 +1,14 @@
+#report {
+	position: absolute;
+	top: 0.5em;
+	right: 0.5em;
+	width: 1.5em;
+}
+
+#report label {
+	cursor: pointer;
+}
+
+#report input {
+	display: none;
+}

--- a/bin/config.py
+++ b/bin/config.py
@@ -5,6 +5,9 @@ override them "manually" or via a ``.env`` file located in the current
 directory. Alternativaly you can use the ``--rtdbin-config`` command line
 option to define a dotenv to load instead of ``./.env``.
 
+It tries to correctly configure logging according to the server software
+you are using
+
 The options are:
 
 * ``RTDBIN_HOST``: The HTTP address the embedded server binds (default: localhost)
@@ -20,10 +23,16 @@ The options are:
 """
 
 
+import logging
 import os
 from argparse import ArgumentParser
 from dotenv import load_dotenv
 from metrics import Byte, Time
+
+
+logger = logging.getLogger(__name__)
+bin_logger = logging.getLogger(__package__)
+
 
 def strtobool(s):
     try:
@@ -32,19 +41,55 @@ def strtobool(s):
         pass
     return s not in {False, "0", "false", "no"}
 
-cli = ArgumentParser()
-cli.add_argument('--rtdbin-port', metavar="PORT", type=int, help="builtin server port")
-cli.add_argument('--rtdbin-config', metavar="PATH", help="dotenv config file")
-options = cli.parse_known_args()[0]
-load_dotenv(options.rtdbin_config)  # use a sensitive default when omitted
 
-HOST = os.getenv('RTDBIN_HOST', 'localhost')
-PORT = options.rtdbin_port or int(os.getenv('RTDBIN_PORT', 8012))
-MAXSIZE = Byte(os.getenv('RTDBIN_MAXSIZE', '16kiB'))
-IDENTSIZE = int(os.getenv('RTDBIN_IDENTSIZE', 6))
-DEFAULT_LANGUAGE = os.getenv('RTDBIN_DEFAULT_LANGUAGE', 'text')
-DEFAULT_MAXUSAGE = int(os.getenv('RTDBIN_DEFAULT_MAXUSAGE', 0))
-DEFAULT_LIFETIME = Time(os.getenv('RTDBIN_DEFAULT_LIFETIME', 0))
-REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
-REDIS_PORT = int(os.getenv('REDIS_PORT', 6379))
-REDIS_DB = int(os.getenv('REDIS_DB', 0))
+def _setup():
+    global HOST, PORT, MAXSIZE, IDENTSIZE
+    global DEFAULT_LANGUAGE, DEFAULT_MAXUSAGE, DEFAULT_LIFETIME
+    global REDIS_HOST, REDIS_PORT, REDIS_DB
+
+    cli = ArgumentParser()
+    cli.add_argument('--rtdbin-port', metavar="PORT", type=int, help="builtin server port")
+    cli.add_argument('--rtdbin-config', metavar="PATH", help="dotenv config file")
+    options = cli.parse_known_args()[0]
+    load_dotenv(options.rtdbin_config)  # use a sensitive default when omitted
+
+    server_software = os.getenv("SERVER_SOFTWARE", "")  # Set by WSGI servers
+
+    # Extact configuration from environ
+    if server_software == "":
+        HOST = os.getenv('RTDBIN_HOST', 'localhost')
+        PORT = options.rtdbin_port or int(os.getenv('RTDBIN_PORT', 8012))
+    MAXSIZE = Byte(os.getenv('RTDBIN_MAXSIZE', '16kiB'))
+    IDENTSIZE = int(os.getenv('RTDBIN_IDENTSIZE', 6))
+    DEFAULT_LANGUAGE = os.getenv('RTDBIN_DEFAULT_LANGUAGE', 'text')
+    DEFAULT_MAXUSAGE = int(os.getenv('RTDBIN_DEFAULT_MAXUSAGE', 0))
+    DEFAULT_LIFETIME = Time(os.getenv('RTDBIN_DEFAULT_LIFETIME', 0))
+    REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
+    REDIS_PORT = int(os.getenv('REDIS_PORT', 6379))
+    REDIS_DB = int(os.getenv('REDIS_DB', 0))
+
+    # Configure logging
+    if "gunicorn" in server_software:
+        gunicorn_logger = logging.getLogger('gunicorn.error')
+        bin_logger.handlers = gunicorn_logger.handlers
+        bin_logger.setLevel(gunicorn_logger.level)
+    elif server_software == "":
+        logging.basicConfig(level='DEBUG')
+    else:
+        logger.warning(
+            "Unknown WSGI server: %s, logging may not work as intended.",
+            server_software
+        )
+
+    # Report config
+    logger.debug(
+        "Detected WSGI server: %s.",
+        server_software or 'builtin wsgiref (unsafe for production)'
+    )
+    logger.debug(
+        "Runtime configuration:\n  %s", "\n  ".join([
+        f"{key}: {val}" for key, val in globals().items()
+        if key.isupper() and not key.startswith('__')
+    ]))
+
+_setup()

--- a/bin/controller.py
+++ b/bin/controller.py
@@ -5,6 +5,7 @@ Various HTTP routes the external world uses to communicate with the application.
 
 import bottle as bt
 import cgi
+import logging
 import re
 from pathlib import Path
 from metrics import Time
@@ -12,6 +13,7 @@ from bin import root, config, models
 from bin.highlight import highlight, parse_language, parse_extension, languages
 
 
+logger = logging.getLogger(__name__)
 BOTUARE = re.compile(r'|'.join([
     re.escape('Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)'),
     re.escape('facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)'),
@@ -124,6 +126,7 @@ def post_new():
         raise bt.HTTPError(400, str(exc))
 
     snippet = models.Snippet.create(code, maxusage, lifetime, parentid)
+    logger.info("New %s snippet of %s chars: %s", lang, len(code), snippet.id)
     bt.redirect(f'/{snippet.id}.{ext}')
 
 

--- a/bin/controller.py
+++ b/bin/controller.py
@@ -145,7 +145,7 @@ def get_html(snippetid, ext=None):
         snippet = models.Snippet.get_by_id(snippetid)
     except KeyError:
         raise bt.HTTPError(404, "Snippet not found")
-    lang = parse_language(ext) or config.DEFAULT_LANGUAGE
+    lang = parse_extension(ext) or config.DEFAULT_LANGUAGE
     codehl = highlight(snippet.code, lang)
     return bt.template(
         'highlight.html',

--- a/bin/controller.py
+++ b/bin/controller.py
@@ -179,3 +179,29 @@ def get_raw(snippetid, ext=None):
 
     bt.response.headers['Content-Type'] = 'text/plain'
     return snippet.code
+
+@bt.route('/report', method='POST')
+def report():
+    """
+    Report a problematic snippet to the system administrator.
+
+    :param snippetid: (form) the reported snippet
+    :param name: (form) the name of the user reporting the problem
+
+    :raises HTTPError: code 400 when any of the snippetid or the name is missing
+    :raises HTTPError: code 404 when the reported snippet is not found
+    """
+    name = bt.request.forms.get("name", "").encode('latin-1').decode().strip()
+    snippetid = bt.request.forms.get("snippetid")
+    if not name:
+        raise bt.HTTPError(400, "Missing name")
+    if not snippetid:
+        raise bt.HTTPError(400, "Missing snippetid")
+
+    try:
+        snippet = models.Snippet.get_by_id(snippetid)
+    except KeyError:
+        raise bt.HTTPError(404, "Snippet not found")
+    logger.warning("The snippet %s got reported by %s", snippetid, name)
+
+    return bt.HTTPResponse("The snippet have been reported.")

--- a/bin/views/head.html
+++ b/bin/views/head.html
@@ -5,7 +5,7 @@
 <meta name=viewport content="width=device-width, initial-scale=1.0">
 <meta name=author content="ReadTheDocs">
 <meta name=title content="ReadTheDocs Bin">
-<meta name=description content="A simple pastebin">
+<meta name=description content="https://github.com/readthedocs-fr/bin-server">
 <meta name=theme-color content="#1e282d">
 <meta name=color-scheme content="only light">
 

--- a/bin/views/highlight.html
+++ b/bin/views/highlight.html
@@ -2,11 +2,25 @@
 <html lang=fr>
     <head>
         % include('head.html')
+        <link rel=stylesheet href="/assets/styles/report.css">
         <link rel=stylesheet href="/assets/styles/monokai.css">
         <script src="/assets/scripts/loc.js" defer></script>
+        <script src="/assets/scripts/report.js" defer></script>
     </head>
     <body>
 {{!codehl}}
+
+        <form id=report title="Signaler" name=report action="/report" method=POST>
+            <input name=snippetid hidden value="{{snippetid}}" required>
+            <input name=name hidden>
+            <label>
+                <input type=submit>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                    <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+                </svg>
+            </label>
+        </form>
+
         <div class="controls">
             % if parentid:
             <a class="control" title="Voir la révision précédente" href="/{{parentid}}.{{ext}}">

--- a/bin/views/newform.html
+++ b/bin/views/newform.html
@@ -5,7 +5,7 @@
         <script src="/assets/scripts/newform.js" defer></script>
     </head>
     <body>
-        <form action="/new" method=POST id=post-snippet accept-charset=utf-8>
+        <form id=post-snippet name=post-snippet action="/new" method=POST accept-charset=utf-8>
             <textarea spellcheck=false placeholder="Entrez votre code ou glissez un fichier." name=code autofocus required>{{code}}</textarea>
             <input type=hidden name=parentid value="{{parentid}}">
 


### PR DESCRIPTION
The pull request embed multiple changes, the most important is the
introduction of logging capacities and a /report route to report
problematic snippets. Those are the two first commits.

Next we have some fixes and cleanups.

---

**feat: new /report endpoint to report a snippet**

There have been incident report about users using the software to host
malwares. While those malware cannot be executed nor on the server nor
in the web page, users might copy/paste them in their own environment
and run them.

In order to take rapid action to remove those snippets, a new "report"
button have been included in the top left corner of the highlight.html
page so users can report a problematic snippet.

Closes #110

---

**feat: introduce logging**

We got feedback from system administrators willing get logs whenever a
snippet was created. Introducing logging was not as simple as it should
be because it needs to correctly hooks to the server software logger
when running behind a wsgi server.

Because we needed much more logics in the config module, we decided to
enclose the setup in a dedicated function in order to limit the exported
tokens.

---

**fix: identify form using name**

---

**fix: lang and extension parsing**

Fine tunning of 5868f01, I am a fucking monkey.

---

**doc: the page description links the github repo**