### PR TITLE
fix(highlight): optional startinline

### DIFF
--- a/bin/highlight.py
+++ b/bin/highlight.py
@@ -93,5 +93,5 @@ _html_formatter = _TableHtmlFormatter(linenos='bin-table', style='monokai')
 
 def highlight(code, language):
     """ Pretty html export of ``code`` using syntax highlighting """
-    lexer = get_lexer_by_name(language)
+    lexer = get_lexer_by_name(language, startinline=True)
     return pygments.highlight(code, lexer, _html_formatter)


### PR DESCRIPTION
Some languages require a startline (such as `<?php` for PHP).
This forces the snippets to have this startline to be (completly) highlighted.
By setting this option to `True`, the startline becomes optional.