### PR TITLE
fix: force identifier length to IDENTSIZE

### DIFF
--- a/bin/models.py
+++ b/bin/models.py
@@ -32,13 +32,17 @@ class Snippet:
         """ Generate a safe unique identifier """
         for _ in range(20):
             ident = pronounceable_passwd(config.IDENTSIZE)
+
+            if len(ident) != config.IDENTSIZE:
+                continue
+            if ident in {'health', 'assets', 'new', 'raw', 'report'}:
+                continue
             if database.exists(ident):
                 continue
-            if ident in {'health', 'assets', 'new', 'raw'}:
-                continue
+
             return ident
 
-        raise RuntimeError("No free identifier has been found after 20 attempts")
+        raise RuntimeError("No free or valid identifier has been found after 20 attempts")
 
 
     @classmethod


### PR DESCRIPTION
Sometimes, the snippet identifier's length can be less than IDENTSIZE.
For exemple, the identifier `efy` exists currently.
This is normal since `pronounceable_passwd` generate
identifier of length in range {3..IDENTSIZE}.

The identifier's length must always be IDENTSIZE.
Now, the identifier's length is checked in `new_id`.

Also, added `report` route.