### PR TITLE
feat(highlight): allow all languages

### DIFF
--- a/bin/controller.py
+++ b/bin/controller.py
@@ -7,11 +7,11 @@ import bottle as bt
 import cgi
 import logging
 import re
+import os.path
 import secrets
-from pathlib import Path
 from metrics import Time
 from bin import root, config, models
-from bin.highlight import highlight, parse_language, parse_extension, languages
+from bin.highlight import highlight, languages, langtoext, exttolang
 
 
 logger = logging.getLogger(__name__)
@@ -94,27 +94,42 @@ def post_new():
 
     token = None
     code = None
-    lang = config.DEFAULT_LANGUAGE
+    lang = None
+    ext = None
     maxusage = config.DEFAULT_MAXUSAGE
     lifetime = config.DEFAULT_LIFETIME
     parentid = ''
 
     try:
+        # Form extraction
         if files:
             part = next(files.values())
             charset = cgi.parse_header(part.content_type)[1].get('charset', 'utf-8')
             code = part.file.read(config.MAXSIZE).decode(charset)
-            lang = parse_extension(Path(part.filename).suffix.lstrip('.')) or lang
+            ext = os.path.splitext(part.filename)[1][1:] or langtoext[config.DEFAULT_LANGUAGE]
         if forms:
             # WSGI forces latin-1 decoding, this is wrong, we recode it in utf-8
             code = forms.get('code', '').encode('latin-1').decode() or code
-            lang = forms.get('lang') or lang
+            lang = forms.get('lang') or config.DEFAULT_LANGUAGE
             maxusage = int(forms.get('maxusage') or maxusage)
             lifetime = Time(forms.get('lifetime') or lifetime)
             parentid = forms.get('parentid', '')
             token = forms.get('token')
 
-        ext = parse_language(lang)
+        # Form validation
+        if lang:
+            ext = langtoext.get(lang)
+            if ext is None:
+                logger.warning('Unknown lang %r, using %r.', lang, config.DEFAULT_LANGUAGE)
+                lang = config.DEFAULT_LANGUAGE
+                ext = langtoext[config.DEFAULT_LANGUAGE]
+
+        if ext:
+            lang = exttolang.get(ext)
+            if lang is None:
+                logger.warning('Unknown file extension %r, using %r.', ext, langtoext[config.DEFAULT_LANGUAGE])
+                lang = config.DEFAULT_LANGUAGE
+                ext = langtoext[config.DEFAULT_LANGUAGE]
         if not code:
             raise ValueError("Code is missing")
         if maxusage < 0:
@@ -155,8 +170,11 @@ def get_html(snippetid, ext=None):
         snippet = models.Snippet.get_by_id(snippetid)
     except KeyError:
         raise bt.HTTPError(404, "Snippet not found")
-    lang = parse_extension(ext) or config.DEFAULT_LANGUAGE
+
+    lang = langtoext.get(ext, config.DEFAULT_LANGUAGE)
+    ext = langtoext[lang]  # always use the prefered extension for that lang
     codehl = highlight(snippet.code, lang)
+
     return bt.template(
         'highlight.html',
         codehl=codehl,
@@ -234,7 +252,7 @@ def report():
         raise bt.HTTPError(400, "Missing snippetid")
 
     try:
-        snippet = models.Snippet.get_by_id(snippetid)
+        models.Snippet.get_by_id(snippetid)
     except KeyError:
         raise bt.HTTPError(404, "Snippet not found")
     logger.warning("The snippet %s got reported by %s", snippetid, name)

--- a/bin/highlight.py
+++ b/bin/highlight.py
@@ -1,10 +1,14 @@
 """ HTML highlighted code export and language tools """
 
-
+import os.path
 import pygments
-from pygments.lexers import get_lexer_by_name
+from pygments.lexers import get_all_lexers, get_lexer_by_name
 from pygments.formatters.html import HtmlFormatter
 
+
+# ==================================================================== #
+#                     Supported langages database                      #
+# ==================================================================== #
 
 languages = [
     # (ext, lang)
@@ -12,6 +16,7 @@ languages = [
     ('cpp', 'cpp'),
     ('cs', 'csharp'),
     ('css', 'css'),
+    ('dart', 'dart'),
     ('diff', 'diff'),
     ('erl', 'erlang'),
     ('ex', 'elixir'),
@@ -23,6 +28,7 @@ languages = [
     ('java', 'java'),
     ('js', 'javascript'),
     ('json', 'json'),
+    ('jl', 'julia'),
     ('kt', 'kotlin'),
     ('less', 'less'),
     ('lisp', 'lisp'),
@@ -48,23 +54,27 @@ languages = [
 exttolang = {ext: lang for ext, lang in languages}
 langtoext = {lang: ext for ext, lang in languages}
 
+def _load_more_languages():
+    """ Save more langs to the ``exttolang`` and ``langtoext`` maps """
+    for name, aliases, globs, _mimetypes in get_all_lexers():
+        if not globs:
+           continue
+        name = name.lower()
+        for glob in globs:
+            ext = os.path.splitext(glob)[1][1:]
+            langtoext.setdefault(name, ext)
+            exttolang.setdefault(ext, name)
+        for alias in aliases:
+            ext = langtoext[name]
+            langtoext.setdefault(alias, ext)
+            exttolang.setdefault(ext, alias)
 
-def parse_extension(ext):
-    """ From a language extension, get a language """
-    ext = (ext or '').casefold()
-    if ext in langtoext:
-        return ext  # this is a lang already
-    return exttolang.get(ext)
+_load_more_languages()
+del _load_more_languages
 
-
-def parse_language(lang):
-    """ From a language name, get an extension """
-    lang = (lang or '').casefold()
-    if lang in exttolang:
-        return lang  # this is an ext already
-    return langtoext.get(lang)
-
-
+# ==================================================================== #
+#                 Plaintext to stylized HTML utilities                 #
+# ==================================================================== #
 
 class _TableHtmlFormatter(HtmlFormatter):
     """

--- a/tests/test_highlight.py
+++ b/tests/test_highlight.py
@@ -8,9 +8,9 @@ class TestHighlight(unittest.TestCase):
         try:
             pygments.lexers.get_lexer_by_name(lang)
             return True
-        except pygments.utils.ClassNotFound:
+        except pygments.util.ClassNotFound:
             return False
 
     def test_languages_has_formatter(self):
-        for lang in highlight.languages:
-            self.assertTrue(self.has_language_formatter(lang[1]))
+        for _ext, lang in highlight.languages:
+            self.assertTrue(self.has_language_formatter(lang))


### PR DESCRIPTION
This allow to use any supported language by Pygments.
These additionals languages are not displayed in the frontend.

To achieve this, highlight "utils" has been greatly refactored.

Closes https://github.com/readthedocs-fr/bin-server/issues/119