### PR TITLE
feat(rtdbin.sh): configurable destination site

### DIFF
--- a/rtdbin.sh
+++ b/rtdbin.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
+test -z $HOST && HOST=https://bin.readthedocs.fr
 test -z $1 && file=- || file=$1
 test -z $1 && lang=txt || lang="${file#*.}"
 curl_version=$(curl -V | head -n1 | cut -d ' ' -f2)
-curl -s -F file=@$file -F "lang=$lang" -w "%{redirect_url}\n" -A "curl/$curl_version (+https://github.com/readthedocs-fr/bin-server)" https://bin.readthedocs.fr/new
+curl -s -F file=@$file -F "lang=$lang" -w "%{redirect_url}\n" -A "curl/$curl_version (+https://github.com/readthedocs-fr/bin-server)" $HOST/new


### PR DESCRIPTION
The `rtdbin.sh` is handy to publish a file using the multipart API, it
sends the file "as-is" instead of embedding it in a web form. Because we
still lack test coverage for the /new route, we have to test the route
manually during the development, because the URL where to publish the
file was hardcoded in the file it was not possible to query a
development server running e.g. at `http://localhost:8012`.

This small change makes it possible to set a `HOST` envvar to send the
request to another site. Use it as follow:

    $ HOST=http://localhost:8012 rtdbin.sh path/to/a/file