### PR TITLE
ci(docker): fix auth by modernizing the workflow file

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -44,8 +44,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository }}
-          password: ${{ secrets.GHCR_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
This workflow file is outdated and instead of regenerating a Github Classic PAT, we are instead aligning with nowadays GitHub best practices.

See: https://github.com/docker/login-action/tree/3227f5311cb93ffd14d13e65d8cc400d30f4dd8a?tab=readme-ov-file#github-container-registry