### PR TITLE
ci(build-release): upgrade to release please v3 (& chores)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     # TODO: upgrade to v4
-    - uses: GoogleCloudPlatform/release-please-action@v2
+    - uses: GoogleCloudPlatform/release-please-action@v3
       id: release
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-python = "3.8.20"
+python = "3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,7 @@ readme = "README.md"
 #requires-python = ">=3.12"
 license = "MIT"
 license-files = ["LICENSE"]
-authors = [
-  { name="Read The Docs", email="opensource@readthedocs.fr" },
-]
+authors = [{ name = "Read The Docs", email = "opensource@readthedocs.fr" }]
 classifiers = [
   "Environment :: No Input/Output (Daemon)",
   "Operating System :: OS Independent",
@@ -30,7 +28,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/readthedocs-fr/bin-server"
-Download = "https://pypi.org/simple/rtd-bin-server//"
+Download = "https://pypi.org/simple/rtd-bin-server/"
 Documentation = "https://rtd-bin-server.readthedocs.io/en/latest/"
 
 


### PR DESCRIPTION
Try the upgrade to v3 from v2.

No migration documentation in the github readme for this upgrade, but one is present for v3 to v4 migration.

I'm assuming migrating to v3 needs no changes on user-side.